### PR TITLE
[Optional] adherence to Telegram's rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ For the Telegram side, you will need to create a new Telegram bot that will sit 
 2. Create a bot with the `/newbot` command in a chat window with BotFather. You will then be prompted to enter a bot name. Once you have done this, you will get a bot token from the BotFather for accessing the Telegram API. Make note of the token for later configuration.
 3. Before this bot can enter any group chats, you will need to configure it with correct permissions. Send the `/setprivacy` command to the BotFather, specify which bot this command is for, then **disable** the privacy so the bot receives all messages sent in the group chat.
 4. Optionally, you can supply a different bot name, description, and picture to make it more obvious what the bot is in the group chat.
-5. Add the bot to the Telegram group chat you want to bridge.
+5. This bot supports adhering to Telegram's bot rate limits. You can set messages per minute in the config. As of this writing, the limit
+from Telegram is 20, which is the default. If you don't want to use rate limiting, set the option to 0. The bot will bundle messages and
+send them together with a delay while rate limiting in hopes of avoiding dropped messages.
+6. Add the bot to the Telegram group chat you want to bridge.
 
 Now that you have a bot created, have its Telegram API token, and have it in your group, you can start using this bridge.
 
@@ -71,7 +74,8 @@ Alternatively, if you start up the bot with no Telegram chat ID set, it will sit
         showJoinMessage: false,
         showActionMessage: true,
         showLeaveMessage: false,
-        showKickMessage: false
+        showKickMessage: false,
+        maxMessagesPerMinute: 20
     }
 }
 ```

--- a/config.js.example
+++ b/config.js.example
@@ -15,7 +15,8 @@ var settings = {
         showJoinMessage: false,
         showActionMessage: true,
         showLeaveMessage: false,
-        showKickMessage: false
+        showKickMessage: false,
+        maxMessagesPerMinute: 20
     }
 }
 

--- a/teleirc.js
+++ b/teleirc.js
@@ -129,7 +129,7 @@ class MessageRateLimiter {
 
         // We need to run periodically to make sure messages don't get stuck
         // in the queue.
-        if (rate === 0) {
+        if (this.rate > 0) {
             setInterval(this.run.bind(this), 2000);
         }
     }

--- a/teleirc.js
+++ b/teleirc.js
@@ -123,7 +123,7 @@ class MessageRateLimiter {
         this.rate = rate;
         this.per = per;
         this.allowance = rate;
-        this.last_check = Date.now();
+        this.last_check = Date.now()/1000;
         this.bundle = new MessageBundle();
         this.sendAction = sendAction;
 
@@ -157,8 +157,9 @@ class MessageRateLimiter {
     }
 
     bumpAllowance() {
-        let current = Date.now();
+        let current = Date.now()/1000;
         let timePassed = current - this.last_check;
+        this.last_check = current;
         this.allowance = this.allowance + (timePassed * this.rate/this.per);
 
         // Make sure we don't get to an allowance that's higher than the


### PR DESCRIPTION
This is most likely less than perfect and I'm not set up to test it (read: make sure to test this before you merge it), but I want to open it up for review and maybe some discussion, as there's a good chance there's a more intelligent way to do this.

As-is, this sends messages immediately until the rate limit gets hit, then starts delaying and bundling messages. For a really active chat period, there might be up to about a 3 second delay for messages arriving in Telegram and the delayed messages will arrive en-masse, using the default settings for Telegram's limits.

Being a little smarter and starting to bundle messages if we notice we're approaching the rate limit might make the delay shorter if chat has short periods of high activity, but with a consistently active chat the 3 second delay would probably end up getting hit anyway. Given that, I'm not sure if the ROI of building logic for that makes it worthwhile.