### PR TITLE
If a user sends a sticker, the corresponding emoji is sent to IRC.

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -7,6 +7,7 @@ var settings = {
         server: "irc.freenode.net",
         channel: "#channel",
         botName: "teleirc",
+        sendStickerEmoji: false,
         prefix: "<",
         suffix: ">"
     },

--- a/teleirc.js
+++ b/teleirc.js
@@ -110,7 +110,7 @@ tgbot.on('message', function (msg) {
                 let username = msg.new_chat_member.username;
                 let first_name = msg.new_chat_member.first_name;
                 ircbot.say(config.channel, "New user " + first_name + " ( @" + username + ") has joined the Telegram Group!");
-            } else if (msg.sticker != undefined) {
+            } else if (msg.sticker !== undefined) {
                 // If we have a sticker, we should send it to IRC... sort of...
                 // The best way to get a sticker to IRC would be to send a URL to the sticker, but that doesn't
                 // seem to exist.  My guess as to how telegram handles stickers is it sends the file ID of the sticker
@@ -120,7 +120,7 @@ tgbot.on('message', function (msg) {
                 // The only thing we can do if we see a sticker is grab its corresponding emoji and send that to IRC.
                 // That is, if the config allows us to do that of course.
                 let emoji = msg.sticker.emoji;
-                if (emoji != undefined && config.irc.sendStickerEmoji) {
+                if (emoji !== undefined && config.irc.sendStickerEmoji) {
                     ircbot.say(config.irc.channel, config.irc.prefix + from + config.irc.suffix + " " + emoji);
                 }
             } else {

--- a/teleirc.js
+++ b/teleirc.js
@@ -110,6 +110,19 @@ tgbot.on('message', function (msg) {
                 let username = msg.new_chat_member.username;
                 let first_name = msg.new_chat_member.first_name;
                 ircbot.say(config.channel, "New user " + first_name + " ( @" + username + ") has joined the Telegram Group!");
+            } else if (msg.sticker != undefined) {
+                // If we have a sticker, we should send it to IRC... sort of...
+                // The best way to get a sticker to IRC would be to send a URL to the sticker, but that doesn't
+                // seem to exist.  My guess as to how telegram handles stickers is it sends the file ID of the sticker
+                // to its servers and downloads it directly from its servers, similar to how photo downloads are done.
+                // That won't work in IRC.
+                //
+                // The only thing we can do if we see a sticker is grab its corresponding emoji and send that to IRC.
+                // That is, if the config allows us to do that of course.
+                let emoji = msg.sticker.emoji;
+                if (emoji != undefined && config.irc.sendStickerEmoji) {
+                    ircbot.say(config.irc.channel, config.irc.prefix + from + config.irc.suffix + " " + emoji);
+                }
             } else {
                 console.log("Ignoring non-text message: " + JSON.stringify(msg));
             }


### PR DESCRIPTION
Probably the best way to send a sticker to IRC is to send a direct URL to the sticker so IRC users can open it up in a web browser.
However, it does not appear as though there is a way to do that.

From what I can guess based on what I've read, what Telegram does when it gets a sticker is it sends the file_id to its servers, and the sticker gets downloaded directly.  Therefore, its not possible to get a static URL to the sticker... unless we want to host the thing ourselves.

The next best thing we can do is send the corresponding sticker emoji to IRC.  They might not get a cool sticker, but they'll get something!

Also, added this as an option.  There may be emoji haters out there.

Testing note: I did test it on my machine with my own telegram group and it seems to work on my side.