### PR TITLE
Assume default of emoji and Telgram=>IRC join messages relaying

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -7,11 +7,11 @@ var settings = {
         server: "irc.freenode.net",
         channel: "#channel",
         botName: "teleirc",
-        sendStickerEmoji: false,
+        sendStickerEmoji: true,
         prefix: "<",
         suffix: ">",
-        showJoinMessage: false,
-        showLeaveMessage: false
+        showJoinMessage: true,
+        showLeaveMessage: true
     },
     tg: {
         chatId: "-0000000000000",


### PR DESCRIPTION
This pull request just changes a few values in the configuration to assume a default of true, for sending stickers as emoji to IRC as well as relaying part messages in Telegram to IRC.