### PR TITLE
Nickserv identify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ IRC_SEND_STICKER_EMOJI=true
 IRC_PREFIX="<"
 IRC_SUFFIX=">"
 IRC_SERVER=chat.freenode.net
+IRC_NICKSERV_SERVICE=NickServ
+IRC_NICKSERV_PASS=""
 
 
 ###############################################################################

--- a/config.js
+++ b/config.js
@@ -12,6 +12,8 @@ let settings = {
     suffix: process.env.IRC_SUFFIX || ">",
     showJoinMessage: process.env.IRC_SHOW_JOIN_MESSAGE === "true" || true,
     showLeaveMessage: process.env.IRC_SHOW_LEAVE_MESSAGE === "true" || true,
+    nickservPassword: process.env.IRC_NICKSERV_PASS || "",
+    nickservService: process.env.IRC_NICKSERV_SERVICE || "",
   },
   tg: {
     chatId: process.env.TELEGRAM_CHAT_ID || "-000000000",

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -190,7 +190,8 @@ class TeleIrc {
    * Identifies to NickServ, if password is provided.
    */
   nickservIdentify() {
-    if (this.config.irc.nickservPassword.length != 0) {
+    if ((this.config.irc.nickservPassword.length > 0) &&
+        (this.config.irc.nickservService.length > 0)) {
       console.log("Identifying to NickServ...");
       this.ircbot.say(
         this.config.irc.nickservService,
@@ -212,7 +213,7 @@ class TeleIrc {
         return from.toLowerCase() === name.toLowerCase();
       });
 
-      if ((this.config.irc.nickservService.length != 0) &&
+      if ((this.config.irc.nickservService.length > 0) &&
           (from.toLowerCase() === this.config.irc.nickservService.toLowerCase())) {
         console.log(`[${this.config.irc.nickservService}] ${message}`);
         return; // we don't want nickserv messages being forwarded to telegram

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -214,8 +214,14 @@ class TeleIrc {
 
       if ((this.config.irc.nickservService.length != 0) &&
           (from.toLowerCase() === this.config.irc.nickservService.toLowerCase())) {
-        console.log("[NickServ] " + message);
+        console.log(`[${this.config.irc.nickservService}] ${message}`);
         return; // we don't want nickserv messages being forwarded to telegram
+      }
+
+      // we want to ignore the messages from not configured channels or direct messages
+      if (channel !== this.config.irc.channel) {
+        console.log(`Ignoring: <${from}@${channel}> ${message}`);
+        return;
       }
 
       if (matchedNames.length <= 0) {

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -193,9 +193,13 @@ class TeleIrc {
     if ((this.config.irc.nickservPassword.length > 0) &&
         (this.config.irc.nickservService.length > 0)) {
       console.log("Identifying to NickServ...");
+      var nickservRegisteredNick = this.config.irc.botName;
+      if (this.config.irc.nickservRegisteredNick.length > 0) {
+        nickservRegisteredNick = this.config.irc.nickservRegisteredNick;
+      }
       this.ircbot.say(
         this.config.irc.nickservService,
-        "IDENTIFY " + this.config.irc.nickservPassword
+        "IDENTIFY " + nickservRegisteredNick + " " + this.config.irc.nickservPassword
       );
     } else {
       console.log("NickServ password not provided - omitting indentification");
@@ -216,6 +220,12 @@ class TeleIrc {
       if ((this.config.irc.nickservService.length > 0) &&
           (from.toLowerCase() === this.config.irc.nickservService.toLowerCase())) {
         console.log(`[${this.config.irc.nickservService}] ${message}`);
+        if (this.ircbot.chans && this.ircbot.chans.indexOf(this.config.irc.channel) == -1) {
+          // we are not in the channel - let's try to join it, hoping that this
+          // message was good news about the bot being identified
+          console.log("Bot not on the specified channel - trying to join...");
+          this.ircbot.join(this.config.irc.channel);
+        }
         return; // we don't want nickserv messages being forwarded to telegram
       }
 

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -180,6 +180,25 @@ class TeleIrc {
   initStage3_initBots(ircbot, tgbot) {
     this.ircbot = ircbot;
     this.tgbot = tgbot;
+
+    this.ircbot.connect(() => {
+      this.nickservIdentify();
+    });
+  }
+
+  /**
+   * Identifies to NickServ, if password is provided.
+   */
+  nickservIdentify() {
+    if (this.config.irc.nickservPassword.length != 0) {
+      console.log("Identifying to NickServ...");
+      this.ircbot.say(
+        this.config.irc.nickservService,
+        "IDENTIFY " + this.config.irc.nickservPassword
+      );
+    } else {
+      console.log("NickServ password not provided - omitting indentification");
+    }
   }
 
   /**
@@ -192,6 +211,12 @@ class TeleIrc {
       let matchedNames = this.config.ircBlacklist.filter((name) => {
         return from.toLowerCase() === name.toLowerCase();
       });
+
+      if ((this.config.irc.nickservService.length != 0) &&
+          (from.toLowerCase() === this.config.irc.nickservService.toLowerCase())) {
+        console.log("[NickServ] " + message);
+        return; // we don't want nickserv messages being forwarded to telegram
+      }
 
       if (matchedNames.length <= 0) {
         this.queueTelegramMessage(

--- a/teleirc.js
+++ b/teleirc.js
@@ -20,7 +20,9 @@ console.log("Starting up bot on IRC...");
 let ircbot = new irc.Client(config.irc.server, config.irc.botName, {
   channels: [config.irc.channel],
   debug: false,
-  username: config.irc.botName
+  username: config.irc.botName,
+  autoConnect: false,
+  autoRejoin: true
 });
 
 // Create the telegram bot side with the settings specified in config object above

--- a/tests/IrcConnectionTests.js
+++ b/tests/IrcConnectionTests.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const nodeAssert = require('assert');
+const TeleIrc = require("../lib/TeleIrc");
+
+const TEST_NICKSERV_PASSWORD = "ThisIsATestPassword";
+const TEST_NICKSERV_SERVICE = "TestNickServServiceNick";
+const TEST_MESSAGE = "Test message body";
+const BLACKLISTED_NICK = "Nasty one!";
+const TEST_SETTINGS = {
+  token: "EXAMPLE_TOKEN",
+  ircBlacklist: [BLACKLISTED_NICK, "some other blacklisted nick"],
+  irc: {
+    server: "EXAMPLE_IRC_SERVER",
+    channel: "#EXAMPLE_IRC_CHANNEL",
+    botName: "",
+    sendStickerEmoji: "",
+    prefix: "<_",
+    suffix: ">_",
+    showJoinMessage: "",
+    showLeaveMessage: "",
+    maxMessageLength: 500,
+    nickservPassword: "default value to be changed in test",
+    nickservService: "default value to be changed in test",
+  },
+  imgur: {
+    seImgurForImageLinks: true,
+    imgurClientId: ""
+  },
+  tg: {
+    chatId: "TEST_ID",
+    showJoinMessage: "",
+    showActionMessage: "",
+    showLeaveMessage: "",
+    showKickMessage: "",
+    maxMessagesPerMinute: 20
+  },
+};
+
+function createTgBotMock(assert) {
+  return {};
+}
+
+function createIrcBotMock(assert, expectedMessages, whatSplitShouldReturn) {
+  return {
+    _splitLongLines: function(line, maxLen, out) {
+      return whatSplitShouldReturn || [line];
+    },
+    connect: function(callback) {callback();},
+    say: function(channel, msg) {
+      assert.equal(this.expectedMessages[this.messageNo].channel, channel);
+      assert.equal(this.expectedMessages[this.messageNo].message, msg);
+      this.messageNo += 1;
+      if (this.messageNo === this.expectedMessages.length) assert.done();
+    },
+    addListener: function(name, callback) {this.listeners[name] = callback;},
+    messageNo: 0,
+    expectedMessages: expectedMessages,
+    listeners: {}
+  };
+}
+
+exports.IrcConnectionTests = {
+  setUp: function(callback) {
+    callback();
+  },
+  tearDown: function(callback) {
+    nodeAssert.strictEqual(this.ircBotMock.messageNo, this.ircBotMock.expectedMessages.length);
+    callback();
+  },
+  "Connecting and identifying to NickServ as configured": function(assert) {
+    const EXPECTED_MESSAGE = [
+      {channel: TEST_NICKSERV_SERVICE, message: `IDENTIFY ${TEST_NICKSERV_PASSWORD}`}
+    ];
+    TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;
+    TEST_SETTINGS.irc.nickservPassword = TEST_NICKSERV_PASSWORD;
+    let uut = new TeleIrc(TEST_SETTINGS);
+    this.ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    this.tgBotMock = createTgBotMock(assert);
+    uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
+  },
+  "Connecting and not identifying to NickServ as no password is provided": function(assert) {
+    const EXPECTED_MESSAGE = [];
+    TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;
+    TEST_SETTINGS.irc.nickservPassword = "";
+    let uut = new TeleIrc(TEST_SETTINGS);
+    this.ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    this.tgBotMock = createTgBotMock(assert);
+    uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
+    assert.done();
+  },
+  "Messages from NickServ will not be forwarded to Telegram": function(assert) {
+    const EXPECTED_MESSAGE = [];
+    TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;
+    TEST_SETTINGS.irc.nickservPassword = "";
+    let uut = new TeleIrc(TEST_SETTINGS);
+    this.ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    this.tgBotMock = createTgBotMock(assert);
+    uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
+    uut.initStage4_addIrcListeners();
+    this.ircBotMock.listeners.message(TEST_NICKSERV_SERVICE, null, "test message");
+    assert.done();
+  },
+  "Messages from blacklisted nicks will not be forwarded to Telegram": function(assert) {
+    const EXPECTED_MESSAGE = [];
+    TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;
+    TEST_SETTINGS.irc.nickservPassword = "";
+    let uut = new TeleIrc(TEST_SETTINGS);
+    this.ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    this.tgBotMock = createTgBotMock(assert);
+    uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
+    uut.initStage4_addIrcListeners();
+    this.ircBotMock.listeners.message(BLACKLISTED_NICK, null, "test message");
+    assert.done();
+  },
+  "Messages not from NickServ and not on blacklist will be forwarded to Telegram": function(assert) {
+    const EXPECTED_NICK = "some other nick";
+    const EXPECTED_MESSAGE = [];
+    TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;
+    TEST_SETTINGS.irc.nickservPassword = "";
+    let uut = new TeleIrc(TEST_SETTINGS);
+    this.ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    uut.tgRateLimiter = {
+      queueMessage: function(text) {
+        assert.equal(text, `<${EXPECTED_NICK}> ${TEST_MESSAGE}`)
+        assert.done();
+      }
+    };
+    this.tgBotMock = createTgBotMock(assert);
+    uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
+    uut.initStage4_addIrcListeners();
+    this.ircBotMock.listeners.message(EXPECTED_NICK, null, TEST_MESSAGE);
+  },
+};

--- a/tests/IrcConnectionTests.js
+++ b/tests/IrcConnectionTests.js
@@ -7,12 +7,13 @@ const TEST_NICKSERV_PASSWORD = "ThisIsATestPassword";
 const TEST_NICKSERV_SERVICE = "TestNickServServiceNick";
 const TEST_MESSAGE = "Test message body";
 const BLACKLISTED_NICK = "Nasty one!";
+const TEST_IRC_CHANNEL = "#EXAMPLE_IRC_CHANNEL";
 const TEST_SETTINGS = {
   token: "EXAMPLE_TOKEN",
   ircBlacklist: [BLACKLISTED_NICK, "some other blacklisted nick"],
   irc: {
     server: "EXAMPLE_IRC_SERVER",
-    channel: "#EXAMPLE_IRC_CHANNEL",
+    channel: TEST_IRC_CHANNEL,
     botName: "",
     sendStickerEmoji: "",
     prefix: "<_",
@@ -110,7 +111,20 @@ exports.IrcConnectionTests = {
     this.tgBotMock = createTgBotMock(assert);
     uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
     uut.initStage4_addIrcListeners();
-    this.ircBotMock.listeners.message(BLACKLISTED_NICK, null, "test message");
+    this.ircBotMock.listeners.message(BLACKLISTED_NICK, TEST_IRC_CHANNEL, "test message");
+    assert.done();
+  },
+  "Messages sent to channel other than the configured one will not be forwarded to Telegram": function(assert) {
+    const EXPECTED_NICK = "some other nick";
+    const EXPECTED_MESSAGE = [];
+    TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;
+    TEST_SETTINGS.irc.nickservPassword = "";
+    let uut = new TeleIrc(TEST_SETTINGS);
+    this.ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    this.tgBotMock = createTgBotMock(assert);
+    uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
+    uut.initStage4_addIrcListeners();
+    this.ircBotMock.listeners.message(EXPECTED_NICK, "some other channel", TEST_MESSAGE);
     assert.done();
   },
   "Messages not from NickServ and not on blacklist will be forwarded to Telegram": function(assert) {
@@ -129,6 +143,6 @@ exports.IrcConnectionTests = {
     this.tgBotMock = createTgBotMock(assert);
     uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
     uut.initStage4_addIrcListeners();
-    this.ircBotMock.listeners.message(EXPECTED_NICK, null, TEST_MESSAGE);
+    this.ircBotMock.listeners.message(EXPECTED_NICK, TEST_IRC_CHANNEL, TEST_MESSAGE);
   },
 };

--- a/tests/IrcConnectionTests.js
+++ b/tests/IrcConnectionTests.js
@@ -90,6 +90,16 @@ exports.IrcConnectionTests = {
     uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
     assert.done();
   },
+  "Connecting and not identifying to NickServ as no service name is provided": function(assert) {
+    const EXPECTED_MESSAGE = [];
+    TEST_SETTINGS.irc.nickservService = "";
+    TEST_SETTINGS.irc.nickservPassword = TEST_NICKSERV_PASSWORD;
+    let uut = new TeleIrc(TEST_SETTINGS);
+    this.ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    this.tgBotMock = createTgBotMock(assert);
+    uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
+    assert.done();
+  },
   "Messages from NickServ will not be forwarded to Telegram": function(assert) {
     const EXPECTED_MESSAGE = [];
     TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;

--- a/tests/IrcConnectionTests.js
+++ b/tests/IrcConnectionTests.js
@@ -3,6 +3,7 @@
 const nodeAssert = require('assert');
 const TeleIrc = require("../lib/TeleIrc");
 
+const TEST_NICKSERV_REGISTERED_NICK = "NickservNick"
 const TEST_NICKSERV_PASSWORD = "ThisIsATestPassword";
 const TEST_NICKSERV_SERVICE = "TestNickServServiceNick";
 const TEST_MESSAGE = "Test message body";
@@ -14,7 +15,7 @@ const TEST_SETTINGS = {
   irc: {
     server: "EXAMPLE_IRC_SERVER",
     channel: TEST_IRC_CHANNEL,
-    botName: "",
+    botName: "exampleBotName",
     sendStickerEmoji: "",
     prefix: "<_",
     suffix: ">_",
@@ -71,8 +72,21 @@ exports.IrcConnectionTests = {
   },
   "Connecting and identifying to NickServ as configured": function(assert) {
     const EXPECTED_MESSAGE = [
-      {channel: TEST_NICKSERV_SERVICE, message: `IDENTIFY ${TEST_NICKSERV_PASSWORD}`}
+      {channel: TEST_NICKSERV_SERVICE, message: `IDENTIFY ${TEST_NICKSERV_REGISTERED_NICK} ${TEST_NICKSERV_PASSWORD}`}
     ];
+    TEST_SETTINGS.irc.nickservRegisteredNick = TEST_NICKSERV_REGISTERED_NICK;
+    TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;
+    TEST_SETTINGS.irc.nickservPassword = TEST_NICKSERV_PASSWORD;
+    let uut = new TeleIrc(TEST_SETTINGS);
+    this.ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    this.tgBotMock = createTgBotMock(assert);
+    uut.initStage3_initBots(this.ircBotMock, this.tgBotMock);
+  },
+  "Connecting and identifying to NickServ as configured, using regular nick when NickServ's registered nick is missing": function(assert) {
+    const EXPECTED_MESSAGE = [
+      {channel: TEST_NICKSERV_SERVICE, message: `IDENTIFY ${TEST_SETTINGS.irc.botName} ${TEST_NICKSERV_PASSWORD}`}
+    ];
+    TEST_SETTINGS.irc.nickservRegisteredNick = "";
     TEST_SETTINGS.irc.nickservService = TEST_NICKSERV_SERVICE;
     TEST_SETTINGS.irc.nickservPassword = TEST_NICKSERV_PASSWORD;
     let uut = new TeleIrc(TEST_SETTINGS);


### PR DESCRIPTION
Bot will `IDENTIFY` itself to NickServ (or other compatible service) after connecting to IRC.

Bonus functionality:
- Messages sent from user with nick configured as `IRC_NICKSERV_SERVICE` will be ignored,
- Messages sent anywhere but on the configured channel are ignored
    - Rationale: someone can spam direct messages at bot and it will be forwarding all that to the telegram group,
    - But mainly: if IRC channel has `+r` and redirection to other channel in case of lack of identification and get forwarded as it wasn't yet identified, it would forward messages from that channel even if this is not what was intended. This could be done better, but there are two solutions I see:
        - A small timeout, after which we assume to be identified and join the intended channel. Kinda fishy,
        - Parsing messages from `NickServ`. Would assume, that NickServs on all servers would behave in the same way. Or we assume we're always on Freenode and hardcode it (or better - leave a regex that can be configured).