### PR TITLE
Update broken documentation link

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -2,5 +2,5 @@ Using Teleirc with Docker
 =========================
 
 The files included here are examples for you to use.
-For more information on using them, [read the documentation](https://teleirc.readthedocs.io/en/latest/using-docker.html).
+For more information on using them, [read the documentation](https://teleirc.readthedocs.io/en/latest/using-docker/).
 Before using them, copy files you intend to use to the root directory of the repository.


### PR DESCRIPTION
When looking at the Dockerfiles, I noticed the link to learn more about using docker with teleirc was broken.

This PR fixes the broken link and points the README to the correct location.