### PR TITLE
Check if we can actually reach Telegram on start

### DIFF
--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -210,8 +210,7 @@ class TeleIrc {
 
     // Verifies that we can, in fact, reach the Telegram API and
     // are not being rate limited.
-    let getmePromise = this.tgbot.getMe();
-    getmePromise.then(function(result) {
+    this.tgbot.getMe().then(function(result) {
         console.log("Connected to Telegram. Our bot name is " + result.username);
     })
     .catch(function(result) {

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -209,7 +209,7 @@ class TeleIrc {
     });
 
     // Verifies that we can, in fact, reach the Telegram API and
-// are not being rate limited.
+    // are not being rate limited.
     let getmePromise = this.tgbot.getMe();
     getmePromise.then(function(result) {
         console.log("Connected to Telegram. Our bot name is " + result.username);

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -188,6 +188,35 @@ class TeleIrc {
   initStage3_initBots(ircbot, tgbot) {
     this.ircbot = ircbot;
     this.tgbot = tgbot;
+    // This is super rudimentary error handling. If the Telegram bot
+    // throws an error, the library we use simply logs it and appears
+    // to hang. This may be a bug in that library (see
+    // https://github.com/yagop/node-telegram-bot-api/issues/657).
+    // This code forces teleirc to fully crash when it encounters a polling
+    // error so that its parent process/container can restart it.
+    // It may be possible to handle this in a nicer way, but issues
+    // open on the bot library indicate that things may not be working right
+    // as of October 2018.
+    this.tgbot.on('polling_error', (error) => {
+        console.log("Fatal Telegram polling error: " + error.code);
+        console.log(error.stack);
+        process.exit(1);
+    });
+    this.tgbot.on('webhook_error', (error) => {
+        console.log("Fatal Telegram webhook error: " + error.code);
+        console.log(error.stack);
+        process.exit(1);
+    });
+
+    // Verifies that we can, in fact, reach the Telegram API and
+// are not being rate limited.
+    let getmePromise = this.tgbot.getMe();
+    getmePromise.then(function(result) {
+        console.log("Connected to Telegram. Our bot name is " + result.username);
+    })
+    .catch(function(result) {
+        console.log("Unable to reach Telegram API. Check that you're not being rate limited.");
+    });
 
     this.ircbot.connect(() => {
       this.nickservIdentify();

--- a/teleirc.js
+++ b/teleirc.js
@@ -28,26 +28,6 @@ let ircbot = new irc.Client(config.irc.server, config.irc.botName, {
 // Create the telegram bot side with the settings specified in config object above
 console.log("Starting up bot on Telegram...");
 let tgbot = new tg(config.token, { polling: true });
-// This is super rudimentary error handling. If the Telegram bot
-// throws an error, the library we use simply logs it and appears
-// to hang. This may be a bug in that library (see
-// https://github.com/yagop/node-telegram-bot-api/issues/657).
-// This code forces teleirc to fully crash when it encounters a polling
-// error so that its parent process/container can restart it.
-// It may be possible to handle this in a nicer way, but issues
-// open on the bot library indicate that things may not be working right
-// as of October 2018.
-tgbot.on('polling_error', (error) => {
-    console.log("Fatal Telegram polling error: " + error.code);
-    console.log(error.stack);
-    process.exit(1);
-});
-tgbot.on('webhook_error', (error) => {
-    console.log("Fatal Telegram webhook error: " + error.code);
-    console.log(error.stack);
-    process.exit(1);
-});
-
 teleIrc.initStage3_initBots(ircbot, tgbot);
 
 console.log("Adding IRC Listeners...");

--- a/tests/IrcConnectionTests.js
+++ b/tests/IrcConnectionTests.js
@@ -40,7 +40,12 @@ const TEST_SETTINGS = {
 };
 
 function createTgBotMock(assert) {
-  return {};
+  return {
+      on: function(foo, bar) {},
+      getMe: function() {
+          return new Promise(function(){}, function(){});
+      }
+  };
 }
 
 function createIrcBotMock(assert, expectedMessages, whatSplitShouldReturn) {


### PR DESCRIPTION
This implements the suggestion in #81. I think this is slightly redundant with the change that makes teleirc crash on Telegram polling errors, but I haven't figured out how to make Telegram rate limit me in a way that I can cause this (nor do I want to figure out how to get myself rate limited).

If this saves some debugging time for someone in the future, then it's worthwhile.