### PR TITLE
Fix Fedora container, validate on Fedora 29 (closes #86)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,21 @@
-# ---> Node
+# ---------------------------------- Docker ------------------------------------
+
+# Example Dockerfiles exist in `containers/`. Copy the base image of your choice
+# to the project root directory as `Dockerfile`. Choose which image suits your
+# needs or preferences.
+Dockerfile
+
+# Docker Compose file
+# Remove when image is pushed to Docker Hub or similar
+docker-compose.yml
+
+# Allow teleirc's lib, which would otherwise be ignored from the python Virtualenv
+# ignores above
+!/lib/
+
+
+# ----------------------------------- Node -------------------------------------
+
 # Logs
 logs
 *.log
@@ -27,9 +44,13 @@ build/Release
 # Dependency directory
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules
+
+# Running config file! Don't commit this unless you know what you're doing.
 .env
 
-# ---> Python (for docs)
+
+# ----------------------------- Python (for docs) ------------------------------
+
 # Virtualenv
 # http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
 .Python
@@ -46,10 +67,3 @@ pip-selfcheck.json
 # Sphinx docs output
 docs/_build
 
-# Docker Compose file
-# Remove when image is pushed to Docker Hub or similar
-docker-compose.yml
-
-# Allow teleirc's lib, which would otherwise be ignored from the python Virtualenv
-# ignores above
-!/lib/

--- a/containers/Dockerfile.fedora
+++ b/containers/Dockerfile.fedora
@@ -1,19 +1,21 @@
-FROM fedora
+FROM fedora:29
+
 # Cache layers which will not change
 RUN groupadd teleirc -g 65532 \
-&& useradd -u 65532 -g teleirc -s /bin/bash -M -d /opt/teleirc teleirc
+    && useradd -u 65532 -g teleirc -s /bin/bash -M -d /opt/teleirc teleirc
 
 WORKDIR /opt/teleirc
-CMD ["node", "teleirc.js"]
 
 COPY . /opt/teleirc/
-COPY config.js.example /opt/teleirc/config.js
+COPY config.js /opt/teleirc/config.js
 
 RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
-&& dnf -y update --setopt=deltarpm=false \
-&& dnf clean all \
-&& dnf -y install nodejs libicu-devel python gcc-c++ make yarn --setopt=deltarpm=false \
-&& yarn \
-&& dnf -y remove libicu-devel gcc-c++ make \
-&& dnf clean all \
-&& chown -R teleirc:teleirc /opt/teleirc
+    && dnf -y upgrade --setopt=deltarpm=false \
+    && dnf -y install nodejs libicu-devel python gcc-c++ make yarn --setopt=deltarpm=false \
+    && yarn \
+    ; dnf -y remove libicu-devel gcc-c++ \
+    && dnf clean all \
+    && chown -R teleirc:teleirc /opt/teleirc
+
+CMD ["node", "teleirc.js"]
+


### PR DESCRIPTION
This one wasn't too complicated, but took some playing around. What changed:

* Fix statements using old paths for files that no longer exist there
* Don't uninstall `make`, since it uninstalls `nodejs`
* `yarn` emits an error code, even if it actually was successful; therefore, run the next command regardless if it fails