### PR TITLE
Remove/update calls to retired method names (closes #87, closes #78)

### DIFF
--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -35,10 +35,6 @@ class TeleIrc {
       this.errorCodes = new TeleIrcErrorCodes();
     }
 
-    if (this.config.imgur.useImgurForImageLinks) {
-      imgur.setClientId(this.config.imgur.imgurClientId);
-    }
-
     // "Constants:"
     this.defaultSendStickerEmoji = false;
     this.defaultIrcPrefix = "";
@@ -334,7 +330,7 @@ class TeleIrc {
     );
     this.tgEventListener.addListener(
       'document',
-      this.tgDocumentHandler.ReportDocument.bind(this.tgDocumentHandler)
+      this.tgDocumentHandler.RelayDocumentMessage.bind(this.tgDocumentHandler)
     );
 
     this.tgErrorHandler = new TgErrorHandler(
@@ -356,7 +352,7 @@ class TeleIrc {
     );
     this.tgEventListener.addListener(
       'join',
-      this.tgJoinHandler.ReportJoin.bind(this.tgJoinHandler)
+      this.tgJoinHandler.RelayJoinMessage.bind(this.tgJoinHandler)
     );
 
     this.tgMsgHandler = new TgMessageHandler(
@@ -375,7 +371,7 @@ class TeleIrc {
     );
     this.tgEventListener.addListener(
       'part',
-      this.tgPartHandler.ReportPart.bind(this.tgPartHandler)
+      this.tgPartHandler.RelayPartMessage.bind(this.tgPartHandler)
     );
 
     if (this.config.imgur.useImgurForImageLinks) {
@@ -395,7 +391,7 @@ class TeleIrc {
     }
     this.tgEventListener.addListener(
       'photo',
-      this.tgPhotoHandler.ReportPhoto.bind(this.tgPhotoHandler)
+      this.tgPhotoHandler.RelayPhotoMessage.bind(this.tgPhotoHandler)
     );
 
     this.tgStickerHandler = new TgStickerHandler(


### PR DESCRIPTION
After #80, a few unused method calls were lying around. For the ones where a clear rename existed, I updated the method name. For the one part where I could not, I removed it.

I manually validated that the bot successfully started and ran. I also [verified](https://i.imgur.com/EShsvZf.jpg) Imgur image upload is working.