### PR TITLE
Set NTBA_FIX_319=1 in env.example (closes #88)

### DIFF
--- a/env.example
+++ b/env.example
@@ -41,3 +41,13 @@ TELEGRAM_CHAT_ID=-0000000000000
 USE_IMGUR_FOR_IMAGES=false
 IMGUR_CLIENT_ID=0000000000
 
+
+###############################################################################
+#                                                                             #
+#                      Misc. required env variables                           #
+#                -- not meant for user config, don't touch --                 #
+#                                                                             #
+###############################################################################
+
+# https://github.com/yagop/node-telegram-bot-api/issues/319#issuecomment-324963294
+NTBA_FIX_319=1


### PR DESCRIPTION
This resolves a deprecation warning given by node-telegram-bot-api about the "automatic enabling of cancellation of promises". Given context from the [issue linked in the upstream project](https://github.com/yagop/node-telegram-bot-api/issues/319#issuecomment-324963294), setting this environment variable will ensure backwards-compatibility with future releases. If we need this feature, then we need to enable it when we need it.