### PR TITLE
Splitting of messages sent to IRC, prepending TG username to each one.

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@ let settings = {
     nickservPassword: process.env.IRC_NICKSERV_PASS || "",
     nickservService: process.env.IRC_NICKSERV_SERVICE || "",
     editedPrefix: process.env.IRC_EDITED_PREFIX || "[EDIT] ",
+    maxMessageLength: Number(process.env.IRC_MAX_MESSAGE_LENGTH) || 400,
   },
   tg: {
     chatId: process.env.TELEGRAM_CHAT_ID || "-000000000",

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -142,6 +142,11 @@ IRC
 - **IRC_NICKSERV_PASS**:
     - IRC password for your bot to use in order to complete IRC authentication (default: ``""``)
 
+- **IRC_MAX_MESSAGE_LENGTH**:
+  
+    - Maximum length of the message that can be sent to IRC. Longer messages
+      will be splitted into multiple messages. (default: ``400``)
+
 Telegram
 ^^^^^^^^
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -143,9 +143,8 @@ IRC
     - IRC password for your bot to use in order to complete IRC authentication (default: ``""``)
 
 - **IRC_MAX_MESSAGE_LENGTH**:
-  
     - Maximum length of the message that can be sent to IRC. Longer messages
-      will be splitted into multiple messages. (default: ``400``)
+      will be split into multiple messages. (default: ``400``)
 
 Telegram
 ^^^^^^^^

--- a/env.example
+++ b/env.example
@@ -16,6 +16,7 @@ IRC_SERVER=chat.freenode.net
 IRC_NICKSERV_SERVICE=NickServ
 IRC_NICKSERV_PASS=""
 IRC_EDITED_PREFIX="[EDIT] "
+IRC_MAX_MESSAGE_LENGTH=400
 
 
 ###############################################################################

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -41,6 +41,7 @@ class TeleIrc {
     this.defaultIrcSuffix = "";
     this.defaultShowJoinMessage = false;
     this.defaultShowLeaveMessage = false;
+    this.defaultMaxMessageLength = 400;
   }
 
   // ---------------- Functions ----------------
@@ -110,6 +111,12 @@ class TeleIrc {
         this.config.irc.showLeaveMessage,
         this.defaultShowLeaveMessage,
         "showLeaveMessage"
+      );
+
+      this.config.irc.maxMessageLength = this.checkConfigOption(
+        this.config.irc.maxMessageLength,
+        this.defaultMaxMessageLength,
+        "maxMessageLength"
       );
     } else {
       throw new TeleIrcException(
@@ -445,11 +452,22 @@ class TeleIrc {
    * Sends a message to the IRC channel.
    * @param {String} message - The message to send to the IRC channel.
    */
-  sendMessageToIrc(message) {
-    this.ircbot.say(
-      this.config.irc.channel,
-      message
-    );
+  sendMessageToIrc(from, message) {
+    const ircbot = this.ircbot;
+    const messagePrefix = this.config.irc.prefix + from + this.config.irc.suffix + " ";
+    const channel = this.config.irc.channel;
+    const maxLength = this.config.irc.maxMessageLength;
+
+    message.toString().split(/\r?\n/).filter(function(line) {
+      return line.length > 0;
+    }).forEach(function(line) {
+      var linesToSend = ircbot._splitLongLines(line, maxLength - messagePrefix.length, []);
+      
+      linesToSend.forEach(function(toSend) {
+        ircbot.say(channel, messagePrefix + toSend);
+      });
+    });
+    
   }
 
   /**

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -450,38 +450,13 @@ class TeleIrc {
 
   /**
    * Sends a message to the IRC channel.
-   * @param {(String|Object)} input - The message to send to the IRC channel.
-   * @param {String} input.from - Name of the user from which the message was received.
-   * @param {String} input.message - Actual message to be sent.
-   * 
-   * If `input` is provided as string, message is forwarded as-is. Otherwise, a prefix is
-   * generated. Messages longer than config.irc.maxMessageLength will be splitted into
-   * multiple messages.
+   * @param {String} message - The message to send to the IRC channel.
    */
-  sendMessageToIrc(input) {
-    var prefix = "";
-    var message = "";
-    if (typeof input === "string") {
-      message = input;
-    }
-    else {
-      prefix = this.config.irc.prefix + input.from + this.config.irc.suffix + " ";
-      message = input.message;
-    }
-    const ircbot = this.ircbot;
-    const channel = this.config.irc.channel;
-    const maxLength = this.config.irc.maxMessageLength;
-
-    message.toString().split(/\r?\n/).filter(function(line) {
-      return line.length > 0;
-    }).forEach(function(line) {
-      var linesToSend = ircbot._splitLongLines(line, maxLength - prefix.length, []);
-      
-      linesToSend.forEach(function(toSend) {
-        ircbot.say(channel, prefix + toSend);
-      });
-    });
-    
+  sendMessageToIrc(message) {
+    this.ircbot.say(
+      this.config.irc.channel,
+      message
+    );
   }
 
   /**

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -419,7 +419,7 @@ class TeleIrc {
 
   /**
    * Sends a message to telegram.
-   * @param messageString - The message to send.
+   * @param {String} messageString - The message to send.
    */
   queueTelegramMessage(messageString) {
     this.tgRateLimiter.queueMessage(messageString);
@@ -450,21 +450,35 @@ class TeleIrc {
 
   /**
    * Sends a message to the IRC channel.
-   * @param {String} message - The message to send to the IRC channel.
+   * @param {(String|Object)} input - The message to send to the IRC channel.
+   * @param {String} input.from - Name of the user from which the message was received.
+   * @param {String} input.message - Actual message to be sent.
+   * 
+   * If `input` is provided as string, message is forwarded as-is. Otherwise, a prefix is
+   * generated. Messages longer than config.irc.maxMessageLength will be splitted into
+   * multiple messages.
    */
-  sendMessageToIrc(from, message) {
+  sendMessageToIrc(input) {
+    var prefix = "";
+    var message = "";
+    if (typeof input === "string") {
+      message = input;
+    }
+    else {
+      prefix = this.config.irc.prefix + input.from + this.config.irc.suffix + " ";
+      message = input.message;
+    }
     const ircbot = this.ircbot;
-    const messagePrefix = this.config.irc.prefix + from + this.config.irc.suffix + " ";
     const channel = this.config.irc.channel;
     const maxLength = this.config.irc.maxMessageLength;
 
     message.toString().split(/\r?\n/).filter(function(line) {
       return line.length > 0;
     }).forEach(function(line) {
-      var linesToSend = ircbot._splitLongLines(line, maxLength - messagePrefix.length, []);
+      var linesToSend = ircbot._splitLongLines(line, maxLength - prefix.length, []);
       
       linesToSend.forEach(function(toSend) {
-        ircbot.say(channel, messagePrefix + toSend);
+        ircbot.say(channel, prefix + toSend);
       });
     });
     

--- a/lib/TelegramHandlers/TgMessageHandler.js
+++ b/lib/TelegramHandlers/TgMessageHandler.js
@@ -36,7 +36,10 @@ class TgMessageHandler {
         }
 
         let username = TgHelpers.ResolveUserName(from);
-        this._action(username, userMessage);
+        this._action({
+            from: username,
+            message:userMessage
+        });
     }
 }
 

--- a/lib/TelegramHandlers/TgMessageHandler.js
+++ b/lib/TelegramHandlers/TgMessageHandler.js
@@ -9,16 +9,16 @@ class TgMessageHandler {
 
     /**
      * 
-     * @param {*} prefixSuffixConfig - Configuration that specifies what the
-     *                                 username's prefix and suffix
-     *                                 shall be.
+     * @param {*} ircConfig - IRC Configuration that specifies what the
+     *                        username's prefix and suffix shall be, and the
+     *                        maximum message length that can be sent through IRC.
      * @param {boolean} enabled - Is this handler enabled?
      * @param {*} action - The action to take when this handler is fired.
      *                     Only parameter is a string, which is the message
      *                     to send out.
      */
-    constructor(prefixSuffixConfig, enabled, action) {
-        this._prefixSuffixConfig = prefixSuffixConfig;
+    constructor(ircConfig, enabled, action) {
+        this._ircConfig = ircConfig;
         this.Enabled = enabled;
         this._action = action;
     }
@@ -31,14 +31,22 @@ class TgMessageHandler {
      * @param {string} userMessage - The message the user sent that we want to relay.
      */
     RelayMessage(from, userMessage) {
-        if (!this.Enabled) {
+        const self = this;
+        if (!self.Enabled) {
             return;
         }
 
         let username = TgHelpers.ResolveUserName(from);
-        this._action({
-            from: username,
-            message:userMessage
+        const messagePrefix = self._ircConfig.prefix + username + self._ircConfig.suffix + " ";
+        const messageSplitRegex = new RegExp(`.\{1,${self._ircConfig.maxMessageLength - messagePrefix.length}}`, 'g');
+
+        userMessage.toString().split(/\r?\n/).filter(function(line) {
+          return line.length > 0;
+        }).forEach(function(line) {
+          var linesToSend = line.match(messageSplitRegex);
+          linesToSend.forEach(function(toSend) {
+            self._action(messagePrefix + toSend);
+          });
         });
     }
 }

--- a/lib/TelegramHandlers/TgMessageHandler.js
+++ b/lib/TelegramHandlers/TgMessageHandler.js
@@ -36,9 +36,7 @@ class TgMessageHandler {
         }
 
         let username = TgHelpers.ResolveUserName(from);
-        let message = this._prefixSuffixConfig.prefix + username + this._prefixSuffixConfig.suffix + " " + userMessage;
-
-        this._action(message);
+        this._action(username, userMessage);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "irc": "~0.5.0",
     "node": "^10",
     "node-telegram-bot-api": "^0.30.0"
+  },
+  "devDependencies": {
+    "nodeunit": "^0.11.2"
   }
 }

--- a/tests/IrcConfigValidationTests.js
+++ b/tests/IrcConfigValidationTests.js
@@ -9,17 +9,24 @@ function shouldThrow(assert, block, errorCode) {
   assert.throws(
     block,
     function(exception) {
-      return exception.errorCode === errorCode
+      let retval = (exception.errorCode === errorCode);
+      if (!retval) {
+        console.log(JSON.stringify(exception));
+        console.trace();
+      }
+      return retval;
     }
   );
 }
 
 // -------- Missing IRC Config Tests --------
 
+exports.ircConfigValidation = {};
+
 /**
  * Ensures if the IRC config is missing completely from our settings, an exception gets thrown.
  */
-exports.ircConfigValidation_MissingIrcConfig = function(assert) {
+exports.ircConfigValidation.MissingIrcConfig = function(assert) {
   // Copy our default settings, but ignore the IRC portion.
   let testSettings = {
     token: config.token,
@@ -72,14 +79,14 @@ function doRequiredSettingsTest(assert, uut, expectedErrorCode) {
  * Ensures if the IRC config is missing its server config, an
  * exception gets thrown.
  */
-exports.ircConfigValidation_missingServerConfig = function(assert) {
+exports.ircConfigValidation["Missing IRC server config causes an exception"] = function(assert) {
   // Copy our default settings, but ignore the server.
   let testSettings = {
     token: config.token,
     irc: {
       // No Server.
-      channel: config.irc.channel,
-      botName: config.irc.botName,
+      channel: "test channel",
+      botName: "test bot name",
       sendStickerEmoji: config.sendStickerEmoji,
       prefix: config.prefix,
       suffix: config.suffix,
@@ -108,18 +115,14 @@ exports.ircConfigValidation_missingServerConfig = function(assert) {
   assert.done();
 }
 
-/**
- * Ensures if the IRC config is missing its channel config, an
- * exception gets thrown.
- */
-exports.ircConfigValidation_missingChannelConfig = function(assert) {
+exports.ircConfigValidation["Missing IRC channel config causes an exception"] = function(assert) {
   // Copy our default settings, but ignore the server.
   let testSettings = {
     token: config.token,
     irc: {
-      server: config.irc.server,
+      server: "test irc server",
       // No channel
-      botName: config.irc.botName,
+      botName: "test bot name",
       sendStickerEmoji: config.sendStickerEmoji,
       prefix: config.prefix,
       suffix: config.suffix,
@@ -148,23 +151,19 @@ exports.ircConfigValidation_missingChannelConfig = function(assert) {
   assert.done();
 }
 
-/**
- * Ensures if the IRC config is missing its channel config, an
- * exception gets thrown.
- */
-exports.ircConfigValidation_missingBotNameConfig = function(assert) {
+exports.ircConfigValidation["Missing IRC bot name causes an exception"] = function(assert) {
   // Copy our default settings, but ignore the server.
   let testSettings = {
     token: config.token,
     irc: {
-      server: config.irc.server,
-      channel: config.irc.channel,
+      server: "test irc server",
+      channel: "test channel",
       // No bot name.
       sendStickerEmoji: config.sendStickerEmoji,
       prefix: config.prefix,
       suffix: config.suffix,
       showJoinMessage: config.showJoinMessage,
-      showLeaveMessage: config.showLeaveMessage
+      showLeaveMessage: config.showLeaveMessage,
     },
     ircBlacklist: config.ircBlacklist,
     tg: config.tg,
@@ -216,16 +215,16 @@ function doDefaultSettingsTest(assert, testSettings) {
  * Ensures if the IRC config is missing optional values, it gets
  * added in as a default.
  */
-exports.ircConfigValidation_defaultSettingsTest_notDefined = function(assert) {
+exports.ircConfigValidation.defaultSettingsTest_notDefined = function(assert) {
   // Copy our default settings, but ignore the IRC showEmoji.
   let testSettings = {
     token: config.token,
     irc: {
       // These three options are required, everything else is optional.
       // If missing, we should use a default setting.
-      server: config.irc.server,
-      channel: config.irc.channel,
-      botName: config.irc.botName,
+      server: "test irc server",
+      channel: "test channel",
+      botName: "test bot name",
       sendStickerEmoji: undefined,
       prefix: undefined,
       suffix: undefined,
@@ -246,16 +245,16 @@ exports.ircConfigValidation_defaultSettingsTest_notDefined = function(assert) {
  * Ensures if the IRC config is missing optional values, it gets
  * added in as a default.
  */
-exports.ircConfigValidation_defaultSettingsTest_setToNull = function(assert) {
+exports.ircConfigValidation.defaultSettingsTest_setToNull = function(assert) {
   // Copy our default settings, but ignore the IRC showEmoji.
   let testSettings = {
     token: config.token,
     irc: {
       // These three options are required, everything else is optional.
       // If missing, we should use a default setting.
-      server: config.irc.server,
-      channel: config.irc.channel,
-      botName: config.irc.botName,
+      server: "test irc server",
+      channel: "test channel",
+      botName: "test bot name",
       sendStickerEmoji: null,
       prefix: null,
       suffix: null,
@@ -276,7 +275,7 @@ exports.ircConfigValidation_defaultSettingsTest_setToNull = function(assert) {
  * Ensures if the IRC config's optional values are set to undefined, it gets
  * set to its default.
  */
-exports.ircConfigValidation_defaultSettingsTest_missingSettings = function(
+exports.ircConfigValidation.defaultSettingsTest_missingSettings = function(
   assert) {
   // Copy our default settings, but ignore the IRC showEmoji.
   let testSettings = {
@@ -284,9 +283,9 @@ exports.ircConfigValidation_defaultSettingsTest_missingSettings = function(
     irc: {
       // These three options are required, everything else is optional.
       // If missing, we should use a default setting.
-      server: config.irc.server,
-      channel: config.irc.channel,
-      botName: config.irc.botName
+      server: "test irc server",
+      channel: "test channel",
+      botName: "test bot name"
     },
     ircBlacklist: config.ircBlacklist,
     tg: config.tg,
@@ -298,7 +297,7 @@ exports.ircConfigValidation_defaultSettingsTest_missingSettings = function(
   assert.done();
 };
 
-exports.ircConfigValidation_checkTypes = (assert) => {
+exports.ircConfigValidation.checkTypes = (assert) => {
   assert.strictEqual(typeof config.irc.sendStickerEmoji, 'boolean');
   assert.strictEqual(typeof config.irc.showJoinMessage, 'boolean');
   assert.strictEqual(typeof config.irc.showLeaveMessage, 'boolean');

--- a/tests/IrcMessageHandlerTests.js
+++ b/tests/IrcMessageHandlerTests.js
@@ -6,92 +6,94 @@ const IrcMessageHandler = require("../lib/IrcHandlers/IrcMessageHandler");
  * Ensures that if the handler is disabled,
  * nothing happens.
  */
-exports.IrcMessageHandler_DisabledTest = function(assert) {
-    var message = undefined;
+exports.IrcMessageHandler = {
+    DisabledTest: function(assert) {
+        var message = undefined;
 
-    let uut = new IrcMessageHandler(
-        undefined,
-        GetMockIrcConfig(),
-        false,
-        (msg) => {message = msg;}
-    );
+        let uut = new IrcMessageHandler(
+            undefined,
+            GetMockIrcConfig(),
+            false,
+            (msg) => {message = msg;}
+        );
 
-    uut.RelayMessage("User", "#channel", "Hello, World!");
+        uut.RelayMessage("User", "#channel", "Hello, World!");
 
-    // Disabled, message should remain undefined.
-    assert.strictEqual(message, undefined);
+        // Disabled, message should remain undefined.
+        assert.strictEqual(message, undefined);
 
-    assert.done();
-};
+        assert.done();
+    },
 
-/**
- * Ensures that if we get a message from a channel
- * we are not in, we ignore the message.
- */
-exports.IrcMessageHandler_IgnoreChannelTest = function(assert) {
-    var message = undefined;
+    /**
+     * Ensures that if we get a message from a channel
+     * we are not in, we ignore the message.
+     */
+    IgnoreChannelTest: function(assert) {
+        var message = undefined;
 
-    let uut = new IrcMessageHandler(
-        undefined,
-        GetMockIrcConfig(),
-        true,
-        (msg) => {message = msg;}
-    );
+        let uut = new IrcMessageHandler(
+            undefined,
+            GetMockIrcConfig(),
+            true,
+            (msg) => {message = msg;}
+        );
 
-    uut.RelayMessage("User", "#badchannel", "Hello, World!");
+        uut.RelayMessage("User", "#badchannel", "Hello, World!");
 
-    // Not the channel we are in, ignore.
-    assert.strictEqual(message, undefined);
+        // Not the channel we are in, ignore.
+        assert.strictEqual(message, undefined);
 
-    assert.done();
-}
+        assert.done();
+    },
 
-/**
- * Ensures that if the handler is enabled,
- * its callback is activated, even if the black-list is undefined.
- */
-exports.IrcMessageHandler_UndefinedBlackListEnabledTest = function(assert) {
-    DoSuccessTest(assert, undefined);
+    /**
+     * Ensures that if the handler is enabled,
+     * its callback is activated, even if the black-list is undefined.
+     */
+    UndefinedBlackListEnabledTest: function(assert) {
+        DoSuccessTest(assert, undefined);
 
-    assert.done();
-};
+        assert.done();
+    },
 
-/**
- * Ensures that if the handler is enabled,
- * its callback is activated, even if the black-list is null.
- */
-exports.IrcMessageHandler_NullBlackListEnabledTest = function(assert) {
-    DoSuccessTest(assert, null);
+    /**
+     * Ensures that if the handler is enabled,
+     * its callback is activated, even if the black-list is null.
+     */
+    NullBlackListEnabledTest: function(assert) {
+        DoSuccessTest(assert, null);
 
-    assert.done();
-};
+        assert.done();
+    },
 
-/**
- * Ensures that if the handler is enabled,
- * its callback is activated, if the user is not in the black-list.
- */
-exports.IrcMessageHandler_NamesNotMatchBlackListEnabledTest = function(assert) {
-    DoSuccessTest(assert, ["Someone"]);
+    /**
+     * Ensures that if the handler is enabled,
+     * its callback is activated, if the user is not in the black-list.
+     */
+    NamesNotMatchBlackListEnabledTest: function(assert) {
+        DoSuccessTest(assert, ["Someone"]);
 
-    assert.done();
-};
+        assert.done();
+    },
 
-exports.IrcMessageHandler_BlackListNamesMatchTest = function(assert) {
-    var message = undefined;
+    BlackListNamesMatchTest: function(assert) {
+        var message = undefined;
 
-    let uut = new IrcMessageHandler(
-        ["user"],
-        GetMockIrcConfig(),
-        true,
-        (msg) => {message = msg;}
-    );
+        let uut = new IrcMessageHandler(
+            ["user"],
+            GetMockIrcConfig(),
+            true,
+            (msg) => {message = msg;}
+        );
 
-    uut.RelayMessage("User", "#channel", "Hello, World!");
+        uut.RelayMessage("User", "#channel", "Hello, World!");
 
-    // Should be disabled, as a black-list name appeared.
-    assert.strictEqual(message, undefined);
+        // Should be disabled, as a black-list name appeared.
+        assert.strictEqual(message, undefined);
 
-    assert.done();
+        assert.done();
+    }
 };
 
 function DoSuccessTest(assert, blackList) {

--- a/tests/TelegramToIrcTests.js
+++ b/tests/TelegramToIrcTests.js
@@ -42,11 +42,8 @@ function createTgBotMock() {
   };
 }
 
-function createIrcBotMock(assert, expectedMessages, whatSplitShouldReturn) {
+function createIrcBotMock(assert, expectedMessages) {
   return {
-    _splitLongLines: function(line, maxLen, out) {
-      return whatSplitShouldReturn || [line];
-    },
     say: function(channel, msg) {
       assert.equal(TEST_SETTINGS.irc.channel, channel);
       assert.equal(this.expectedMessages[this.messageNo], msg);
@@ -108,13 +105,24 @@ exports.TelegramToIrcTests = {
   "Forwarding a long message": function(assert) {
     const USERNAME = "TEST_USERNAME";
     const EXPECTED_MESSAGES = [
-      "<_TEST_USERNAME>_ line 1",
-      "<_TEST_USERNAME>_ line 2"
+      "<_TEST_USERNAME>_ Lorem ipsum dolor sit amet, consectetur \
+adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore \
+magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation \
+ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute \
+irure dolor in reprehenderit in voluptate velit esse cillum dolore \
+eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, \
+sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum \
+dolor   HERE IT SPLITS>|",
+      "<_TEST_USERNAME>_ |<THIS WAS SPLITTED sed do eiusmod tempor \
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, \
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo \
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse \
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat \
+non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
     ];
-    const SPLITTED_MESSAGE = ["line 1", "line 2"];
 
     let uut = new TeleIrc(TEST_SETTINGS);
-    let ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGES, SPLITTED_MESSAGE);
+    let ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGES);
     let tgBotMock = createTgBotMock();
     uut.initStage3_initBots(ircBotMock, tgBotMock);
     uut.initStage5_initTelegramMessageSending();
@@ -126,7 +134,20 @@ exports.TelegramToIrcTests = {
       from: {
         username: USERNAME
       },
-      text: "EXAMPLE"
+      text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit,\
+ sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\
+ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris\
+ nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in\
+ reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla\
+ pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa\
+ qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor\
+   HERE IT SPLITS>||<THIS WAS SPLITTED\
+ sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\
+ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris\
+ nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in\
+ reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla\
+ pariatur. Excepteur sint occaecat cupidatat non proident, sunt in\
+ culpa qui officia deserunt mollit anim id est laborum."
     });
   },
 };

--- a/tests/TelegramToIrcTests.js
+++ b/tests/TelegramToIrcTests.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const TeleIrc = require("../lib/TeleIrc");
+
+const TEST_SETTINGS = {
+  token: "EXAMPLE_TOKEN",
+  ircBlacklist: "",
+  irc: {
+    server: "EXAMPLE_IRC_SERVER",
+    channel: "#EXAMPLE_IRC_CHANNEL",
+    botName: "",
+    sendStickerEmoji: "",
+    prefix: "<_",
+    suffix: ">_",
+    showJoinMessage: "",
+    showLeaveMessage: "",
+    maxMessageLength: 500
+  },
+  imgur: {
+    seImgurForImageLinks: true,
+    imgurClientId: ""
+  },
+  tg: {
+    chatId: "TEST_ID",
+    showJoinMessage: "",
+    showActionMessage: "",
+    showLeaveMessage: "",
+    showKickMessage: "",
+    maxMessagesPerMinute: 20
+  },
+};
+
+function createTgBotMock() {
+  return {
+    on: function(messageName, callback) {
+      this.callbacks[messageName] = callback;
+    },
+    callbacks: {},
+    getMe: async function() {
+      return Promise.resolve({ username:"test" });
+    }
+  };
+}
+
+function createIrcBotMock(assert, expectedMessages, whatSplitShouldReturn) {
+  return {
+    _splitLongLines: function(line, maxLen, out) {
+      return whatSplitShouldReturn || [line];
+    },
+    say: function(channel, msg) {
+      assert.equal(TEST_SETTINGS.irc.channel, channel);
+      assert.equal(this.expectedMessages[this.messageNo], msg);
+      this.messageNo += 1;
+      if (this.messageNo === this.expectedMessages.length) assert.done();
+    },
+    messageNo: 0,
+    expectedMessages: expectedMessages,
+    connect: function() {}
+  };
+}
+
+exports.TelegramToIrcTests = {
+  "Forwarding a simple message": function(assert) {
+    const USERNAME = "TEST_USERNAME";
+    const EXPECTED_MESSAGE = ["<_TEST_USERNAME>_ TEST_MESSAGE_BODY"];
+    const MESSAGE_FROM_TELEGRAM = "TEST_MESSAGE_BODY";
+
+    let uut = new TeleIrc(TEST_SETTINGS);
+    let ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGE);
+    let tgBotMock = createTgBotMock();
+    uut.initStage3_initBots(ircBotMock, tgBotMock);
+    uut.initStage5_initTelegramMessageSending();
+
+    tgBotMock.callbacks["message"]({
+      chat: {
+        id: TEST_SETTINGS.tg.chatId
+      },
+      from: {
+        username: USERNAME
+      },
+      text: MESSAGE_FROM_TELEGRAM
+    });
+  },
+  "Forwarding a multiline message": function(assert) {
+    const USERNAME = "TEST_USERNAME";
+    const EXPECTED_MESSAGES = [
+      "<_TEST_USERNAME>_ line 1",
+      "<_TEST_USERNAME>_ line 2"
+    ];
+    const MESSAGE_FROM_TELEGRAM = "line 1\n\nline 2";
+
+    let uut = new TeleIrc(TEST_SETTINGS);
+    let ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGES);
+    let tgBotMock = createTgBotMock();
+    uut.initStage3_initBots(ircBotMock, tgBotMock);
+    uut.initStage5_initTelegramMessageSending();
+
+    tgBotMock.callbacks["message"]({
+      chat: {
+        id: TEST_SETTINGS.tg.chatId
+      },
+      from: {
+        username: USERNAME
+      },
+      text: MESSAGE_FROM_TELEGRAM
+    });
+  },
+  "Forwarding a long message": function(assert) {
+    const USERNAME = "TEST_USERNAME";
+    const EXPECTED_MESSAGES = [
+      "<_TEST_USERNAME>_ line 1",
+      "<_TEST_USERNAME>_ line 2"
+    ];
+    const SPLITTED_MESSAGE = ["line 1", "line 2"];
+
+    let uut = new TeleIrc(TEST_SETTINGS);
+    let ircBotMock = createIrcBotMock(assert, EXPECTED_MESSAGES, SPLITTED_MESSAGE);
+    let tgBotMock = createTgBotMock();
+    uut.initStage3_initBots(ircBotMock, tgBotMock);
+    uut.initStage5_initTelegramMessageSending();
+
+    tgBotMock.callbacks["message"]({
+      chat: {
+        id: TEST_SETTINGS.tg.chatId
+      },
+      from: {
+        username: USERNAME
+      },
+      text: "EXAMPLE"
+    });
+  },
+};

--- a/tests/TgMessageHandlerTests.js
+++ b/tests/TgMessageHandlerTests.js
@@ -48,9 +48,9 @@ exports.TgMessageHandler = {
         let uut = new TgMessageHandler(
             prefixSuffixConfig,
             true,
-            (actualUsername, actualMessage) => {
-                assert.strictEqual(expectedMessage, actualMessage);
-                assert.strictEqual(expectedUsername, actualUsername);
+            (input) => {
+                assert.strictEqual(expectedMessage, input.message);
+                assert.strictEqual(expectedUsername, input.from);
                 assert.done();
             }
         );
@@ -67,9 +67,9 @@ exports.TgMessageHandler = {
         let uut = new TgMessageHandler(
             prefixSuffixConfig,
             true,
-            (actualUsername, actualMessage) => {
-                assert.strictEqual(expectedMessage, actualMessage);
-                assert.strictEqual(expectedUsername, actualUsername);
+            (input) => {
+                assert.strictEqual(expectedMessage, input.message);
+                assert.strictEqual(expectedUsername, input.from);
                 assert.done();
             }
         );

--- a/tests/TgMessageHandlerTests.js
+++ b/tests/TgMessageHandlerTests.js
@@ -21,73 +21,59 @@ let prefixSuffixConfig = {
 /**
  * Ensures nothing happens it the handler is disabled.
  */
-exports.TgMessageHandler_DisabledTest = function(assert) {
-    var message = undefined;
+exports.TgMessageHandler = {
+    "Nothing happens when disabled": function(assert) {
+        var message = undefined;
 
-    let uut = new TgMessageHandler(
-        prefixSuffixConfig,
-        false,
-        (msg) => {message = msg;}
-    );
+        let uut = new TgMessageHandler(
+            prefixSuffixConfig,
+            false,
+            (uname, msg) => {
+                assert.fail("Messages should not be forwarded when disabled!");
+            }
+        );
 
-    uut.RelayMessage(fromNoUsername, "My Message");
+        uut.RelayMessage(fromNoUsername, "My Message");
 
-    assert.strictEqual(undefined, message);
-    assert.done();
-};
+        assert.strictEqual(undefined, message);
+        assert.done();
+    },
+    "If user has no username, first name is reported": function(assert) {
+        var actualMessage = undefined;
+        var actualUsername = undefined;
 
-/**
- * Ensures that if the handler is enabled, but the user
- * has no username, we report the user's first name.
- */
-exports.TgMessageHandler_EnabledNoUserName = function(assert) {
-    var message = undefined;
+        let expectedMessage = "My Message";
+        let expectedUsername = fromWithUserName.first_name;
 
-    let userMessage = "My Message";
+        let uut = new TgMessageHandler(
+            prefixSuffixConfig,
+            true,
+            (actualUsername, actualMessage) => {
+                assert.strictEqual(expectedMessage, actualMessage);
+                assert.strictEqual(expectedUsername, actualUsername);
+                assert.done();
+            }
+        );
 
-    let expectedMessage =
-        prefixSuffixConfig.prefix +
-        fromNoUsername.first_name +
-        prefixSuffixConfig.suffix +
-        " " +
-        userMessage;
+        uut.RelayMessage(fromNoUsername, expectedMessage);
+    },
+    "Username is reported if it is available": function(assert) {
+        var actualMessage = undefined;
+        var actualUsername = undefined;
 
-    let uut = new TgMessageHandler(
-        prefixSuffixConfig,
-        true,
-        (msg) => {message = msg;}
-    );
+        let expectedMessage = "My Message";
+        let expectedUsername = fromWithUserName.username;
 
-    uut.RelayMessage(fromNoUsername, userMessage);
+        let uut = new TgMessageHandler(
+            prefixSuffixConfig,
+            true,
+            (actualUsername, actualMessage) => {
+                assert.strictEqual(expectedMessage, actualMessage);
+                assert.strictEqual(expectedUsername, actualUsername);
+                assert.done();
+            }
+        );
 
-    assert.strictEqual(expectedMessage, message);
-    assert.done();
-};
-
-/**
- * Ensures that if the handler is enabled, but the user
- * has username, we report just the user's username.
- */
-exports.TgMessageHandler_EnabledWithUserName = function(assert) {
-    var message = undefined;
-
-    let userMessage = "My Message";
-
-    let expectedMessage =
-        prefixSuffixConfig.prefix +
-        fromWithUserName.username +
-        prefixSuffixConfig.suffix +
-        " " +
-        userMessage;
-
-    let uut = new TgMessageHandler(
-        prefixSuffixConfig,
-        true,
-        (msg) => {message = msg;}
-    );
-
-    uut.RelayMessage(fromWithUserName, userMessage);
-
-    assert.strictEqual(expectedMessage, message);
-    assert.done();
+        uut.RelayMessage(fromWithUserName, expectedMessage);
+    },
 };

--- a/tests/TgMessageHandlerTests.js
+++ b/tests/TgMessageHandlerTests.js
@@ -16,6 +16,7 @@ let fromWithUserName = {
 let prefixSuffixConfig = {
     prefix : "<",
     suffix : ">",
+    maxMessageLength: 400,
 };
 
 /**
@@ -42,38 +43,38 @@ exports.TgMessageHandler = {
         var actualMessage = undefined;
         var actualUsername = undefined;
 
-        let expectedMessage = "My Message";
+        let sentMessage = "My Message";
         let expectedUsername = fromWithUserName.first_name;
+        let expectedMessage = `<${expectedUsername}> My Message`;
 
         let uut = new TgMessageHandler(
             prefixSuffixConfig,
             true,
             (input) => {
-                assert.strictEqual(expectedMessage, input.message);
-                assert.strictEqual(expectedUsername, input.from);
+                assert.strictEqual(expectedMessage, input);
                 assert.done();
             }
         );
 
-        uut.RelayMessage(fromNoUsername, expectedMessage);
+        uut.RelayMessage(fromNoUsername, sentMessage);
     },
     "Username is reported if it is available": function(assert) {
         var actualMessage = undefined;
         var actualUsername = undefined;
 
-        let expectedMessage = "My Message";
+        let sentMessage = "My Message";
         let expectedUsername = fromWithUserName.username;
+        let expectedMessage = `<${expectedUsername}> My Message`;
 
         let uut = new TgMessageHandler(
             prefixSuffixConfig,
             true,
             (input) => {
-                assert.strictEqual(expectedMessage, input.message);
-                assert.strictEqual(expectedUsername, input.from);
+                assert.strictEqual(expectedMessage, input);
                 assert.done();
             }
         );
 
-        uut.RelayMessage(fromWithUserName, expectedMessage);
+        uut.RelayMessage(fromWithUserName, sentMessage);
     },
 };


### PR DESCRIPTION
Should fix #53. Not tested in live environment.

Also fixed / improved some UTs. Especially hardcoded some config values in tests - some of them would fail if you don't have teleirc configured properly in the first place, what should not be required in UT IMHO.