### PR TITLE
Use all system packages for Fedora Docker image

### DIFF
--- a/containers/Dockerfile.fedora
+++ b/containers/Dockerfile.fedora
@@ -6,11 +6,10 @@ RUN groupadd teleirc -g 65532 \
 
 COPY . /opt/teleirc/
 
-RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
-    && dnf -y upgrade --setopt=deltarpm=false \
-    && dnf -y install nodejs libicu-devel python gcc-c++ make yarn --setopt=deltarpm=false \
-    && yarn \
-    ; dnf -y remove libicu-devel gcc-c++ \
+RUN dnf -y upgrade --setopt=deltarpm=false \
+    && dnf -y install nodejs nodejs-yarn libicu-devel python gcc-c++ make --setopt=deltarpm=false \
+    && nodejs-yarn \
+    && dnf -y remove libicu-devel gcc-c++ \
     && dnf clean all \
     && chown -R teleirc:teleirc /opt/teleirc
 


### PR DESCRIPTION
When testing @Tjzabel's tests in #106, I discovered that `yarn` is actually a package in Fedora. It's cleaner to set it up like this. Additionally, `yarn` stops giving an error code for successful completion when it's done this way too, which is nice.

This is a trivial change. I did test it out this morning and the bot started up without issues.