### PR TITLE
Proof of concept response to quoted data

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@ let settings = {
     nickservPassword: process.env.IRC_NICKSERV_PASS || "",
     nickservService: process.env.IRC_NICKSERV_SERVICE || "",
     editedPrefix: process.env.IRC_EDITED_PREFIX || "[EDIT] ",
+    replyToPrefix: process.env.IRC_REPLY_TO_PREFIX || "[REPLY TO THIS BELOW]",
   },
   tg: {
     chatId: process.env.TELEGRAM_CHAT_ID || "-000000000",

--- a/env.example
+++ b/env.example
@@ -16,7 +16,7 @@ IRC_SERVER=chat.freenode.net
 IRC_NICKSERV_SERVICE=NickServ
 IRC_NICKSERV_PASS=""
 IRC_EDITED_PREFIX="[EDIT] "
-
+IRC_REPLY_TO_PREFIX="[REPLY TO THIS BELOW]"
 
 ###############################################################################
 #                                                                             #

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -311,6 +311,7 @@ class TeleIrc {
     this.tgEventListener = new TgEventListener({
       chatId: this.config.tg.chatId,
       ircEditedPrefix: this.config.irc.editedPrefix,
+      replyToPrefix: this.config.irc.replyToPrefix,
     });
 
     let teleirc = this;
@@ -321,6 +322,8 @@ class TeleIrc {
         teleirc.tgbot.sendMessage(teleirc.config.tg.chatId, message);
       });
 
+    this.tgbot.on('message', teleirc.tgEventListener.ParseRepliedMessage.bind(teleirc.tgEventListener));
+    this.tgbot.on('edited_message', teleirc.tgEventListener.ParseRepliedMessage.bind(teleirc.tgEventListener));
     this.tgbot.on('message', teleirc.tgEventListener.ParseMessage.bind(teleirc.tgEventListener));
     this.tgbot.on('edited_message', teleirc.tgEventListener.ParseEditedMessage.bind(teleirc.tgEventListener));
 

--- a/lib/TelegramHandlers/TgEventListener.js
+++ b/lib/TelegramHandlers/TgEventListener.js
@@ -16,10 +16,11 @@ class TgEventListener extends EventEmitter {
      *
      * @param {string} chatId - The group ID of the chat.
      */
-    constructor({chatId, ircEditedPrefix}) {
+    constructor({chatId, ircEditedPrefix, replyToPrefix}) {
         super();
         this._chatId = chatId;
         this._ircEditPrefix = ircEditedPrefix;
+        this._replyToPrefix = replyToPrefix;
     }
 
     // ---------------- Functions ----------------
@@ -29,16 +30,10 @@ class TgEventListener extends EventEmitter {
      * that is subscribed to.
      */
     ParseMessage(msg) {
-        // If the message's group chat ID does not match
-        // the bots, fire a special event.
-        if (msg.chat.id != this._chatId) { // Use != instead of !==, as _chatId could be a string from config.js.
-            super.emit('bad_chat_id', msg.chat, msg);
-        }
-
         // There are several types of Telegram messages.
         // Let's start with an easy one... if the Message's text is defined,
         // it means it is a message that we received.
-        else if (msg.text) {
+        if (msg.text) {
             super.emit('message', msg.from, msg.text);
         }
 
@@ -80,6 +75,45 @@ class TgEventListener extends EventEmitter {
         }
     }
 
+    ParseRepliedMessage(msg) {
+        // If the message's group chat ID does not match
+        // the bots, fire a special event.
+        if (msg.chat.id != this._chatId) { // Use != instead of !==, as _chatId could be a string from config.js.
+            super.emit('bad_chat_id', msg.chat, msg);
+        }
+
+        // If message was quoted/replied to this object should exist
+        // with all metadata of the previous message.
+        else if (msg.reply_to_message) {
+          console.log(msg.reply_to_message);
+          // If that's a reply to a text message
+          if (msg.reply_to_message.photo) {
+            console.log(msg);
+            const captionText = msg.caption || msg.reply_to_message.caption || '';
+            super.emit('photo', msg.from, msg.reply_to_message.photo, `${this._replyToPrefix} to this image${captionText}`);
+            this.ParseMessage(msg);
+          } else if (msg.reply_to_message.sticker) {
+            super.emit('message', msg.from, `${this._replyToPrefix}$${msg.reply_to_message.from.username}: ${msg.reply_to_message.sticker.emoji}`);
+            this.ParseMessage(msg);
+          } else if (msg.reply_to_message.document) {
+            super.emit('document', `${this._replyToPrefix}${msg.reply_to_message.from}`, msg.reply_to_message.document);
+            this.ParseMessage(msg);
+          }
+          else if (msg.reply_to_message.chat && msg.reply_to_message.text) {
+          const messageWithReply = `${this._replyToPrefix}${msg.reply_to_message.from.username} ${msg.reply_to_message.text}`;
+          if (messageWithReply.length >= 120) {
+            const shortenedMessage = `${messageWithReply.slice(0, 117)}...`;
+            super.emit('message', msg.from, shortenedMessage);
+          } else {
+            super.emit('message', msg.from, messageWithReply);
+          }
+          this.ParseMessage(msg);
+
+            //  Else if that's a photo
+        } else {
+          return this.ParseMessage(msg);
+        }
+
     ParseEditedMessage(msg) {
       if (msg.text) {
         return this.ParseMessage(Object.assign({}, msg, {
@@ -89,6 +123,7 @@ class TgEventListener extends EventEmitter {
         return this.ParseMessage(msg);
       }
     }
+  }
 }
 
 module.exports = TgEventListener;


### PR DESCRIPTION
A proof of concept pull request to kind of properly show quoted/response to messages. Due to the refactor it's a bit problematic to do this without race conditions - see for instance `TgPhotoHandler.js` and method `RelayPhotoMessage`, that `await`s for file resolution. Unfortunately current mechanism has no way to properly await for the file resolution making my solution pretty unusable - to actually make it work properly codebase would require a bit of refactor.