### PR TITLE
docs: Fix all Sphinx warnings by changing hyperlink targets

### DIFF
--- a/docs/who-uses-teleirc.rst
+++ b/docs/who-uses-teleirc.rst
@@ -4,37 +4,37 @@ Who uses Teleirc?
 
 The following list of projects and communities use RITlug Teleirc:
 
--  `CityZen app <https://cityzenapp.co>`_ (`Telegram <https://t.me/CityZenApp>`_ | `IRC <https://webchat.freenode.net/?channels=cityzen>`_)
+-  `CityZen app <https://cityzenapp.co>`_ (`@CityZenApp <https://t.me/CityZenApp>`_ | `#cityzen <https://webchat.freenode.net/?channels=cityzen>`_)
 
--  `Fedora Project <https://docs.fedoraproject.org/en-US/project/>`_ (`Telegram <https://t.me/fedora>`_ | `IRC <https://webchat.freenode.net/?channels=fedora-telegram>`_)
-    -  `Fedora Albania <https://www.facebook.com/fedorasq/>`_ (`Telegram <https://t.me/FedoraAlbania>`_ | `IRC <https://webchat.freenode.net/?channels=fedora-sq>`_)
-    -  `Fedora CommOps <https://docs.fedoraproject.org/en-US/commops/>`_ (`Telegram <https://t.me/fedoracommops>`_ | `IRC <https://webchat.freenode.net/?channels=fedora-commops>`_ )
-    -  `Fedora Diversity and Inclusion Team <https://docs.fedoraproject.org/en-US/diversity-inclusion/team/>`_ (`Telegram <https://t.me/fedoradiversity>`_ | `IRC <https://webchat.freenode.net/?channels=fedora-diversity>`_ )
-    -  `Fedora LATAM <http://fedoracommunity.org/latam>`__ (`Telegram <https://t.me/fedoralat>`__ | `IRC <https://webchat.freenode.net/?channels=fedora-latam>`__)
-    -  `Fedora Marketing Team <https://fedoraproject.org/wiki/Marketing>`_ (`Telegram <https://t.me/fedoramktg>`_ | `IRC <https://webchat.freenode.net/?channels=fedora-mktg>`_ )
-    -  `Flock to Fedora <https://flocktofedora.org>`_ (`Telegram <https://t.me/flocktofedora>`_ | `IRC <https://webchat.freenode.net/?channels=fedora-flock>`_)
+-  `Fedora Project <https://docs.fedoraproject.org/en-US/project/>`_ (`@fedora <https://t.me/fedora>`_ | `#fedora-telegram <https://webchat.freenode.net/?channels=fedora-telegram>`_)
+    -  `Fedora Albania <https://www.facebook.com/fedorasq/>`_ (`@FedoraAlbania <https://t.me/FedoraAlbania>`_ | `#fedora-sq <https://webchat.freenode.net/?channels=fedora-sq>`_)
+    -  `Fedora CommOps <https://docs.fedoraproject.org/en-US/commops/>`_ (`@fedoracommops <https://t.me/fedoracommops>`_ | `#fedora-commops <https://webchat.freenode.net/?channels=fedora-commops>`_ )
+    -  `Fedora Diversity and Inclusion Team <https://docs.fedoraproject.org/en-US/diversity-inclusion/team/>`_ (`@fedoradiversity <https://t.me/fedoradiversity>`_ | `#fedora-diversity <https://webchat.freenode.net/?channels=fedora-diversity>`_ )
+    -  `Fedora LATAM <http://fedoracommunity.org/latam>`__ (`@fedoralat <https://t.me/fedoralat>`__ | `#fedora-latam <https://webchat.freenode.net/?channels=fedora-latam>`__)
+    -  `Fedora Marketing Team <https://fedoraproject.org/wiki/Marketing>`_ (`@fedoramktg <https://t.me/fedoramktg>`_ | `#fedora-mktg <https://webchat.freenode.net/?channels=fedora-mktg>`_ )
+    -  `Flock to Fedora <https://flocktofedora.org>`_ (`@flocktofedora <https://t.me/flocktofedora>`_ | `#fedora-flock <https://webchat.freenode.net/?channels=fedora-flock>`_)
 
--  `FOSS@MAGIC at RIT <http://foss.rit.edu>`_ (`Telegram <https://t.me/fossrit>`_  | `IRC <https://webchat.freenode.net/?channels=rit-foss>`_)
+-  `FOSS@MAGIC at RIT <http://foss.rit.edu>`_ (`@fossrit <https://t.me/fossrit>`_  | `#rit-foss <https://webchat.freenode.net/?channels=rit-foss>`_)
 
-- `Hamara Linux Project <https://hamaralinux.org>`_ (`Telegram
-  <https://t.me/hamaraLinux>`_ | `IRC <https://webchat.oftc.net/?channels=#hamara>`_)
+- `Hamara Linux <https://hamaralinux.org>`_ (`@hamaraLinux
+  <https://t.me/hamaraLinux>`_ | `#hamara <https://webchat.oftc.net/?channels=#hamara>`_)
 
--  `LibreOffice Community <https://www.libreoffice.org/>`_ (`Telegram <https://t.me/libreofficecommunity>`_ | `IRC <https://webchat.freenode.net/?channels=libreoffice-telegram>`_)
-    -  `LibreLadies <https://www.mail-archive.com/libreladies@documentfoundation.org/info.html>`_ (*Telegram invite-only* | `IRC <https://webchat.freenode.net/?channels=libreladies>`_)
-    -  `LibreOffice AppImage <https://appimage.org/>`_ (*No Telegram @groupname* | `IRC <https://webchat.freenode.net/?channels=libreoffice-appimage>`_)
-    -  `LibreOffice Design Team <https://wiki.documentfoundation.org/Design>`_ (*No Telegram @groupname* | `IRC <https://webchat.freenode.net/?channels=libreoffice-design>`_)
-    -  `LibreOffice QA Team <https://www.libreoffice.org/community/qa/>`_ (*No Telegram @groupname* | `IRC <https://webchat.freenode.net/?channels=libreoffice-qa>`_)
+-  `LibreOffice Community <https://www.libreoffice.org/>`_ (`@libreofficecommunity <https://t.me/libreofficecommunity>`_ | `#libreoffice-telegram <https://webchat.freenode.net/?channels=libreoffice-telegram>`_)
+    -  `LibreLadies <https://www.mail-archive.com/libreladies@documentfoundation.org/info.html>`_ (*Telegram invite-only* | `#libreladies <https://webchat.freenode.net/?channels=libreladies>`_)
+    -  `LibreOffice AppImage <https://appimage.org/>`_ (*no public invite link* | `#libreoffice-appimage <https://webchat.freenode.net/?channels=libreoffice-appimage>`_)
+    -  `LibreOffice Design Team <https://wiki.documentfoundation.org/Design>`_ (*no public invite link* | `#libreoffice-design <https://webchat.freenode.net/?channels=libreoffice-design>`_)
+    -  `LibreOffice QA Team <https://www.libreoffice.org/community/qa/>`_ (*no public invite link* | `#libreoffice-qa <https://webchat.freenode.net/?channels=libreoffice-qa>`_)
 
 - `Linux Users Massa Carrara <https://www.lumacaonline.org/>`_ (`Telegram <https://t.me/joinchat/Afu_TAczLfB4dQRKeYQCqg>`_ | `IRC <https://www.lumacaonline.org/webchat.php>`_)
 
--  `MINECON Agents <https://mojang.com/2016/06/calling-all-agents-help-us-run-minecon-2016/>`_ (*Telegram invite-only* | `IRC <https://webchat.esper.net/?channels=MineconAgents>`_)
+-  `MINECON Agents <https://mojang.com/2016/06/calling-all-agents-help-us-run-minecon-2016/>`_ (*no public invite link* | `#MineconAgents <https://webchat.esper.net/?channels=MineconAgents>`_)
 
--  `MusicBrainz <https://musicbrainz.org/doc/About>`_ (`Telegram <https://t.me/musicbrainz>`_ | `IRC <https://webchat.freenode.net/?channels=musicbrainz-telegram>`_)
+-  `MusicBrainz <https://musicbrainz.org/doc/About>`_ (`@musicbrainz <https://t.me/musicbrainz>`_ | `#musicbrainz-telegram <https://webchat.freenode.net/?channels=musicbrainz-telegram>`_)
 
--  `Pure Data <https://puredata.info/>`_ (`Telegram <https://t.me/puredata>`_ | `IRC <https://webchat.freenode.net/?channels=dataflow>`_)
+-  `Pure Data <https://puredata.info/>`_ (`@puredata <https://t.me/puredata>`_ | `#dataflow <https://webchat.freenode.net/?channels=dataflow>`_)
 
--  `RITlug <http://ritlug.com>`_ (*Telegram invite-only* | `IRC <https://webchat.freenode.net/?channels=ritlug>`_)
-    -  `RITlug teleirc <https://github.com/RITlug/teleirc>`_ (`Telegram <https://t.me/teleirc>`_ \| `IRC <https://webchat.freenode.net/?channels=ritlug-teleirc>`_)
+-  `RITlug <https://ritlug.com>`_ (`@ritlug <https://t.me/ritlug>`_ | `#ritlug <https://webchat.freenode.net/?channels=ritlug>`_)
+    -  `RITlug teleirc <https://github.com/RITlug/teleirc>`_ (`@teleirc <https://t.me/teleirc>`_ | `#ritlug-teleirc <https://webchat.freenode.net/?channels=ritlug-teleirc>`_)
 
 
 ***********************


### PR DESCRIPTION
This commit changes all of the hyperlink targets for different
communities using Teleirc. Instead of listing an entry like this:

    - My community (Telegram | IRC)

I switched to writing them this like this:

    - My community (@mycommunity | #my-community)

This resolves all the Sphinx warnings when building the docs. Sphinx
doesn't like it when multiple hyperlink targets share the same text.
This commit mostly scratches an annoying itch when working with the
docs.