### PR TITLE
docs: Add new FAQ section with common troubleshooting steps (closes #85, closes #119)

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,25 @@
+##########################
+Frequently asked questions
+##########################
+
+This page collects frequently asked scenarios or problems with Teleirc.
+Did you find something confusing?
+Please let us know in our developer chat or open a new pull request with a suggestion!
+
+
+********
+Telegram
+********
+
+**How do I find a chat ID for a Telegram group?**
+    The chat ID is found when viewing results from the Telegram API from a web browser.
+    First, add your bot to the group.
+    Then, open a browser and enter the Telegram API URL with your API token, as explained in `this post <https://stackoverflow.com/questions/32423837/telegram-bot-how-to-get-a-group-chat-id/32572159#32572159>`_.
+    Next, send a message in the group with the bot username and refresh the browser window.
+    You will see the chat ID for the Telegram group along with other information.
+
+**I reinstalled Teleirc after it was inactive for a while. But the bot doesn't work. Why?**
+    If a Telegram bot is not used for a while, it "goes to sleep".
+    Even if Teleirc is configured and installed correctly, you need to "wake up" the bot.
+    To fix this, *remove the bot from the group and add it again*.
+    Restart Teleirc and it should work again.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Today, it is used by various communities.
    quick-install
    deploy-teleirc
    config-file-glossary
+   faq
    who-uses-teleirc
 
 
@@ -34,6 +35,7 @@ Our developer community is found in these channels.
 Indices and tables
 ******************
 
+* `github.com/RITlug/teleirc <https://github.com/RITlug/teleirc>`_
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`


### PR DESCRIPTION
Closes #85. Closes #119.

This commit adds a new _Frequently asked questions_ page to the docs. I
populated it with two questions specific to Telegram:

* How do I find a chat ID for a Telegram group?
* I reinstalled Teleirc after it was inactive for a while. But the bot
  doesn’t work. Why?

The first question addresses issue #119. Hopefully this better explains
a common challenge with the Telegram API: how to find a chat ID number.

The second question addresses issue #85 with a problem we found when
reactivating a really old bot, specifically the one used in the
`@fedora` supergroup. This edge case is mentioned in the FAQ, so I think
it's fair to close this issue too.

![Screenshot preview of "Frequently asked questions" page](https://user-images.githubusercontent.com/4721034/52906099-70d0a480-3213-11e9-82a6-f8bfc5bd2b63.png "Screenshot preview of \"Frequently asked questions\" page")
