### PR TITLE
TgDocuments Overhaul

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ let settings = {
     channel: process.env.IRC_CHANNEL || "",
     botName: process.env.IRC_BOT_NAME || "teleirc",
     sendStickerEmoji: process.env.IRC_SEND_STICKER_EMOJI === "true" || true,
+    sendDocument: process.env.IRC_SEND_DOCUMENT === "true" || false,
     prefix: process.env.IRC_PREFIX || "<",
     suffix: process.env.IRC_SUFFIX || ">",
     showJoinMessage: process.env.IRC_SHOW_JOIN_MESSAGE === "true" || true,

--- a/docs/config-file-glossary.rst
+++ b/docs/config-file-glossary.rst
@@ -23,6 +23,9 @@ IRC settings
 ``IRC_SEND_STICKER_EMOJI=true``
     Send emojis associated with a sticker to IRC (when a Telegram user sends a sticker)
 
+``IRC_SEND_DOCUMENT=false``
+    Send documents and files from Telegram to IRC (`why is this false by default? <https://github.com/RITlug/teleirc/issues/115>`_)
+
 ``IRC_PREFIX="<"``
     Text displayed before Telegram name in IRC
 
@@ -76,7 +79,7 @@ Telegram settings
 Imgur settings
 **************
 
-``USE_IMGUR_FOR_IMAGES=false``
+``USE_IMGUR_FOR_IMAGES=true``
     Upload picture messages from Telegram to Imgur, send Imgur link to IRC
 
 ``IMGUR_CLIENT_ID=0000000000``

--- a/docs/quick-install.rst
+++ b/docs/quick-install.rst
@@ -84,17 +84,18 @@ Relay Telegram picture messages via Imgur
 -----------------------------------------
 
 Teleirc retrieves picture messages via the Telegram API.
-By default, picture messages from Telegram are viewable from the given Telegram API URL.
-However, API links expire and eventually break.
-Optionally, Teleirc uploads an image to Imgur and replaces the Telegram API URL with a link to Imgur instead.
-This makes picture messages more durable for logs or for someone joining the conversation later.
+By default, picture messages from Telegram are sent to IRC through Imgur.
+`See context <https://github.com/RITlug/teleirc/issues/115>`_ for why Imgur is enabled by default.
+
+.. note:: By default, Teleirc uses the generic Imgur API key.
+          Imgur highly recommends registering each Teleirc bot.
 
 To add Imgur support, follow these steps:
 
 #. Create an Imgur account
 #. `Register your bot <https://api.imgur.com/oauth2/addclient>`_ with the Imgur API
     - Select *OAuth2 without callback* option
-#. Put client ID into ``.env`` file and enable using Imgur
+#. Put client ID into ``.env`` file
 
 
 .. [#] @BotFather is the `Telegram bot <https://core.telegram.org/bots>`_ for `creating Telegram bots <https://core.telegram.org/bots#6-botfather>`_

--- a/env.example
+++ b/env.example
@@ -10,6 +10,7 @@ IRC_BLACKLIST=""
 IRC_BOT_NAME=teleirc
 IRC_CHANNEL=#channel
 IRC_SEND_STICKER_EMOJI=true
+IRC_SEND_DOCUMENT=false
 IRC_PREFIX="<"
 IRC_SUFFIX=">"
 IRC_SERVER=chat.freenode.net
@@ -40,7 +41,7 @@ TELEGRAM_CHAT_ID=-0000000000000
 #                                                                             #
 ###############################################################################
 
-USE_IMGUR_FOR_IMAGES=false
+USE_IMGUR_FOR_IMAGES=true
 IMGUR_CLIENT_ID=0000000000
 
 

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -37,6 +37,7 @@ class TeleIrc {
 
     // "Constants:"
     this.defaultSendStickerEmoji = false;
+    this.defaultSendDocument = false;
     this.defaultIrcPrefix = "";
     this.defaultIrcSuffix = "";
     this.defaultShowJoinMessage = false;
@@ -87,6 +88,12 @@ class TeleIrc {
         this.config.irc.sendStickerEmoji,
         this.defaultSendStickerEmoji,
         "sendStickerEmoji"
+      );
+
+      this.config.irc.sendDocument = this.checkConfigOption(
+        this.config.irc.sendDocument,
+        this.defaultSendDocument,
+        "false"
       );
 
       this.config.irc.prefix = this.checkConfigOption(
@@ -334,7 +341,7 @@ class TeleIrc {
     // ---- Set up Telegram Handlers ----
 
     this.tgDocumentHandler = new TgDocumentHandler(
-      this.config.sendDocument,
+      this.config.irc.sendDocument,
       this.tgbot,
       this.sendMessageToIrc.bind(this)
     );

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -331,10 +331,10 @@ class TeleIrc {
     this.tgbot.on('message', teleirc.tgEventListener.ParseMessage.bind(teleirc.tgEventListener));
     this.tgbot.on('edited_message', teleirc.tgEventListener.ParseEditedMessage.bind(teleirc.tgEventListener));
 
-    // ---- Setup Telegram Handlers ----
+    // ---- Set up Telegram Handlers ----
 
     this.tgDocumentHandler = new TgDocumentHandler(
-      true,
+      this.config.sendDocument,
       this.tgbot,
       this.sendMessageToIrc.bind(this)
     );

--- a/lib/TelegramHandlers/TgDocumentHandler.js
+++ b/lib/TelegramHandlers/TgDocumentHandler.js
@@ -30,14 +30,19 @@ class TgDocumentHandler {
      */
     async RelayDocumentMessage(from, document) {
         if (!this.Enabled) {
-            return;
-        }
+            let username = TgHelpers.ResolveUserName(from);
+            let message = username + 
+                        " shared a file on Telegram with caption: 'test'";
+            // TODO get caption of document 
 
-        let username = TgHelpers.ResolveUserName(from);
+            this._action(message);
 
-        let url = await this._tgbot.getFileLink(document.file_id);
+        } else {
+            let username = TgHelpers.ResolveUserName(from);
 
-        let message = username +
+            let url = await this._tgbot.getFileLink(document.file_id);
+
+            let message = username +
                         " Posted File: " +
                         document.file_name + 
                         " (" + 
@@ -47,7 +52,8 @@ class TgDocumentHandler {
                         " bytes): " +
                         url;
 
-        this._action(message);
+            this._action(message);
+        }
     }
 }
 

--- a/lib/TelegramHandlers/TgDocumentHandler.js
+++ b/lib/TelegramHandlers/TgDocumentHandler.js
@@ -1,4 +1,5 @@
 const TgHelpers = require('./TgHelpers.js');
+const Helpers = require('../Helpers.js');
 
 /**
  * Handles the event when a user sends a document to the Telegram Group.
@@ -27,33 +28,40 @@ class TgDocumentHandler {
      * 
      * @param {*} from - Object that contains the information about the user name.
      * @param {*} document - The information about the document.
+     * @param {string} caption - The caption of the document, if any
      */
-    async RelayDocumentMessage(from, document) {
-        if (!this.Enabled) {
-            let username = TgHelpers.ResolveUserName(from);
-            let message = username + 
-                        " shared a file on Telegram with caption: 'test'";
-            // TODO get caption of document 
+    async RelayDocumentMessage(from, document, caption) {
+        let username = TgHelpers.ResolveUserName(from);
+        let url = await this._tgbot.getFileLink(document.file_id);
 
-            this._action(message);
+        let message = this._GetDocumentMessage(caption, username, url);
+        this._action(message);
+    }
 
-        } else {
-            let username = TgHelpers.ResolveUserName(from);
+    /**
+     * Generates the message to send out
+     * @param {string} caption - The caption of the document
+     * @param {string} from - User who sent the photo
+     * @param {string} fileUrl - URL to the document
+    */
+    _GetDocumentMessage(caption, from, fileUrl) {
+        var message;
 
-            let url = await this._tgbot.getFileLink(document.file_id);
-
-            let message = username +
-                        " Posted File: " +
-                        document.file_name + 
-                        " (" + 
-                        document.mime_type +
-                        ", " + 
-                        document.file_size +
-                        " bytes): " +
-                        url;
-
-            this._action(message);
+        if (Helpers.IsNullOrUndefined(caption)) {
+            caption = "Untitled Document";
         }
+
+        if (!this.Enabled) {
+            message = from +
+                    " shared a file on Telegram with caption: " + 
+                    "'" + caption + "'";
+        } else {
+            message = "'" + caption + "'" + 
+            " uploaded by " + 
+            from + ": " + 
+            fileUrl;
+        }
+    return message;
     }
 }
 

--- a/lib/TelegramHandlers/TgEventListener.js
+++ b/lib/TelegramHandlers/TgEventListener.js
@@ -71,7 +71,7 @@ class TgEventListener extends EventEmitter {
 
         // And having a document means we have a document message.
         else if (msg.document) {
-            super.emit('document', msg.from, msg.document);
+            super.emit('document', msg.from, msg.document, msg.caption);
         }
 
         // Everything else is a message type we do not support yet.

--- a/lib/TelegramHandlers/TgMessageHandler.js
+++ b/lib/TelegramHandlers/TgMessageHandler.js
@@ -40,6 +40,7 @@ class TgMessageHandler {
         const messagePrefix = self._ircConfig.prefix + username + self._ircConfig.suffix + " ";
         const messageSplitRegex = new RegExp(`.\{1,${self._ircConfig.maxMessageLength - messagePrefix.length}}`, 'g');
 
+        // split messages based on max message length, and prepend username on each new line
         userMessage.toString().split(/\r?\n/).filter(function(line) {
           return line.length > 0;
         }).forEach(function(line) {

--- a/lib/TelegramHandlers/TgPhotoHandler.js
+++ b/lib/TelegramHandlers/TgPhotoHandler.js
@@ -43,7 +43,7 @@ class TgPhotoHandler {
             return;
         }
 
-        // To send a photo a photo, we must first get the URL of the photo.
+        // To send a photo, we must first get its URL
         let tgUrl = await this._tgbot.getFileLink(photo.file_id);
 
         // Then, upload it somewhere, classes that extend this class determine that.

--- a/lib/TelegramHandlers/TgPhotoHandler.js
+++ b/lib/TelegramHandlers/TgPhotoHandler.js
@@ -28,7 +28,7 @@ class TgPhotoHandler {
      * 
      * @param {*} from - Object that contains the information about the user name.
      * @param {*} photoList - The information about the photos we can get from Telegram.
-     * @param {string} - The caption of the photo, if any.
+     * @param {string} caption - The caption of the photo, if any.
      */
     async RelayPhotoMessage(from, photoList, caption) {
         if (!this.Enabled) {


### PR DESCRIPTION
The goal of this PR is to take care of:

1. Issue #115 
2. Enabling Imgur by default
3. Overhaul of TgDocumentHandler unit tests
4. Documentation surrounding these issues

### TL;DR
This PR removes the telegram bot's API from showing when images and files are sent over Telegram. Imgur is now enabled by default, and sending documents over Telegram is now set to `false` by default, and sends a message over to IRC with the document's caption so the IRC side isn't completely left out.