### PR TITLE
Add zero width space in Telegram usernames sent to IRC (closes #113).

### DIFF
--- a/lib/TelegramHandlers/TgHelpers.js
+++ b/lib/TelegramHandlers/TgHelpers.js
@@ -10,7 +10,8 @@ module.exports.ResolveUserName = function(from) {
         return from.first_name;
     }
     
-    return from.username;
+    // Add ZWP to remove IRC highlighting when Telegram + IRC nicks are the same
+    return from.username.substr(0,1) + "\u200B" + from.username.substr(1);
 };
 
 /**

--- a/tests/TelegramToIrcTests.js
+++ b/tests/TelegramToIrcTests.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const TeleIrc = require("../lib/TeleIrc");
+const TgHelper = require("../lib/TelegramHandlers/TgHelpers.js");
 
 const TEST_SETTINGS = {
   token: "EXAMPLE_TOKEN",
@@ -54,6 +55,15 @@ function createIrcBotMock(assert, expectedMessages) {
     expectedMessages: expectedMessages,
     connect: function() {}
   };
+}
+
+// Override default method to not use zero width spaces
+TgHelper.ResolveUserName = function(from) {
+  if (from.username === undefined) {
+    return from.first_name;
+  }
+
+  return from.username;
 }
 
 exports.TelegramToIrcTests = {

--- a/tests/TgMessageHandlerTests.js
+++ b/tests/TgMessageHandlerTests.js
@@ -12,6 +12,11 @@ let fromWithUserName = {
     username : "username"
 };
 
+let fromWithZWP = {
+    first_name : "First Name",
+    username : "u" + "\u200B" + "sername"
+}
+
 // Subset of the IRC config.
 let prefixSuffixConfig = {
     prefix : "<",
@@ -40,8 +45,6 @@ exports.TgMessageHandler = {
         assert.done();
     },
     "If user has no username, first name is reported": function(assert) {
-        var actualMessage = undefined;
-        var actualUsername = undefined;
 
         let sentMessage = "My Message";
         let expectedUsername = fromWithUserName.first_name;
@@ -59,8 +62,6 @@ exports.TgMessageHandler = {
         uut.RelayMessage(fromNoUsername, sentMessage);
     },
     "Username is reported if it is available": function(assert) {
-        var actualMessage = undefined;
-        var actualUsername = undefined;
 
         let sentMessage = "My Message";
         let expectedUsername = fromWithUserName.username;
@@ -77,4 +78,21 @@ exports.TgMessageHandler = {
 
         uut.RelayMessage(fromWithUserName, sentMessage);
     },
+    "Zero-width space is inserted into username": function(assert) {
+        
+        let sentMessage = "My Message";
+        let expectedUsername = fromWithZWP.username;
+        let expectedMessage = `<${expectedUsername}> My Message`;
+
+        let uut = new TgMessageHandler (
+            prefixSuffixConfig,
+            true,
+            (input) => {
+                assert.strictEqual(expectedMessage, input);
+                assert.done();
+            }
+        );
+
+        uut.RelayMessage(fromWithZWP, sentMessage);
+    }
 };


### PR DESCRIPTION
This PR solves the problem of a user accidentally pinging himself on IRC when the user's Telegram and IRC nicks are the same.