### PR TITLE
Always write project name as TeleIRC (for branding)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Contributing to Teleirc
+Contributing to TeleIRC
 =======================
 
 <!--
@@ -6,7 +6,7 @@ Contributing to Teleirc
     This makes git diffs easier to read.
 -->
 
-This document is a guide on how to contribute to the Teleirc project.
+This is a guide on how to contribute to the TeleIRC project.
 It explicitly defines working practices of the development team.
 The goal of this document is to help new contributors get up to speed with working on the project.
 It is a living document and may change.
@@ -27,11 +27,11 @@ If you think something could be better, please [open an issue](https://github.co
 1. [Requirements](#requirements)
 2. [Create Telegram bot](#create-telegram-bot)
 3. [Create Telegram group](#create-telegram-group)
-4. [Configure and run Teleirc](#configure-and-run-teleirc)
+4. [Configure and run TeleIRC](#configure-and-run-teleirc)
 
 ### Requirements
 
-To set up a Teleirc development environment, you need the following:
+To set up a TeleIRC development environment, you need the following:
 
 * [Nodejs](https://nodejs.org/en/) (v10+ preferred)
 * Telegram account
@@ -41,13 +41,13 @@ To set up a Teleirc development environment, you need the following:
 ### Create Telegram bot
 
 Create a Telegram bot using the Telegram [BotFather](https://t.me/botfather).
-See [Teleirc documentation](https://teleirc.readthedocs.io/en/latest/quick-install/#create-a-telegram-bot) for more instructions on how to do this.
+See [TeleIRC documentation](https://teleirc.readthedocs.io/en/latest/quick-install/#create-a-telegram-bot) for more instructions on how to do this.
 
 ### Create Telegram group
 
 Create a new Telegram group for testing.
 Invite the bot user as another member to the group.
-Configure the Telegram bot to Teleirc specifications before adding it to the group.
+Configure the Telegram bot to TeleIRC specifications before adding it to the group.
 
 ### Register IRC channel
 
@@ -56,11 +56,11 @@ At the least, you need an unused IRC channel to use for testing.
 Registering the channel gives you additional privileges as a channel operator (e.g. testing NickServ authentication to join private IRC channels).
 See your IRC network's documentation on registering a channel.
 
-### Configure and run Teleirc
+### Configure and run TeleIRC
 
 Change the `env.example` file to `.env`.
 Change the configuration values to the Telegram bot's tokens.
-For more help with configuration, see the [Teleirc documentation](https://teleirc.readthedocs.io/en/latest/quick-install/#configure-and-run-teleirc).
+For more help with configuration, see the [TeleIRC documentation](https://teleirc.readthedocs.io/en/latest/quick-install/#configure-and-run-teleirc).
 
 
 ## Open a new pull request

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Teleirc
+TeleIRC
 =======
 
-<a href="https://github.com/RITlug/teleirc"><img src="/brand/svg/horizontal_color.svg" alt="Teleirc logo by Ura Design" width="60%" height="auto"></a>
+<a href="https://github.com/RITlug/teleirc"><img src="/brand/svg/horizontal_color.svg" alt="TeleIRC logo by Ura Design" width="60%" height="auto"></a>
 
 [![Build Status](https://travis-ci.org/RITlug/teleirc.svg?branch=devel)](https://travis-ci.org/RITlug/teleirc)
 [![Documentation Status](https://readthedocs.org/projects/teleirc/badge/?version=latest)](http://teleirc.readthedocs.io/en/latest/?badge=latest)
@@ -12,8 +12,8 @@ NodeJS implementation of a [Telegram](https://telegram.org/) <=> [IRC](https://e
 
 ## About
 
-**RITlug Teleirc** is a NodeJS implementation of a [Telegram](https://telegram.org/) <=> [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat) bridge.
-Teleirc works with any IRC channel and Telegram group.
+**RITlug TeleIRC** is a NodeJS implementation of a [Telegram](https://telegram.org/) <=> [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat) bridge.
+TeleIRC works with any IRC channel and Telegram group.
 It bridges messages between a Telegram group and an IRC channel.
 
 This bot was originally written for [RITlug](https://ritlug.com).
@@ -28,24 +28,24 @@ Our developer community is found in these channels.
 * **[IRC](https://webchat.freenode.net/?channels=ritlug-teleirc)** (#ritlug-teleirc @ irc.freenode.net)
 
 
-## Contribute to Teleirc
+## Contribute to TeleIRC
 
 See our [contributing guidelines](https://github.com/RITlug/teleirc/master/.github/CONTRIBUTING.md).
 
 
-## Who uses Teleirc?
+## Who uses TeleIRC?
 
-See what projects and communities use Teleirc.
+See what projects and communities use TeleIRC.
 
-[Who uses Teleirc?](https://teleirc.readthedocs.io/en/latest/who-uses-teleirc/ "Who uses Teleirc?")
+[Who uses TeleIRC?](https://teleirc.readthedocs.io/en/latest/who-uses-teleirc/ "Who uses TeleIRC?")
 
 
 ## Documentation
 
-See the [project documentation](https://teleirc.readthedocs.io/) to install and use Teleirc.
+See the [project documentation](https://teleirc.readthedocs.io/) to install and use TeleIRC.
 
 
 ## License
 
-Teleirc is provided under the [MIT License](https://github.com/RITlug/teleirc/blob/master/LICENSE).
-If you're working on Teleirc, please share improvements back upstream!
+TeleIRC is provided under the [MIT License](https://github.com/RITlug/teleirc/blob/master/LICENSE).
+If you're working on TeleIRC, please share improvements back upstream!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# RITlug Teleirc documentation build configuration file, created by
+# RITlug TeleIRC documentation build configuration file, created by
 # sphinx-quickstart on Wed Mar 14 12:56:56 2018.
 #
 # This file is execfile()d with the current directory set to its
@@ -48,7 +48,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'RITlug Teleirc'
+project = 'RITlug TeleIRC'
 copyright = '2018-2019 CC-BY SA 4.0'
 author = \
     'Mark Repka, ' \
@@ -57,7 +57,7 @@ author = \
     'Robby O\'Connor, ' \
     'Justin W. Flory, ' \
     'RITlug, ' \
-    'and Teleirc community'
+    'and TeleIRC community'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -125,7 +125,7 @@ html_sidebars = {
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'RITlugTeleircdoc'
+htmlhelp_basename = 'RITlugTeleIRCdoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -152,9 +152,9 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'RITlugTeleirc.tex', 'RITlug Teleirc Documentation',
+    (master_doc, 'RITlugTeleIRC.tex', 'RITlug TeleIRC Documentation',
      'Mark Repka, Seth Hendrick, Nate Levesque, Robby O\'Connor, '
-     'Justin W. Flory, RITlug, and Teleirc community', 'manual'),
+     'Justin W. Flory, RITlug, and TeleIRC community', 'manual'),
 ]
 
 
@@ -163,7 +163,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ritlugteleirc', 'RITlug Teleirc Documentation',
+    (master_doc, 'ritlugteleirc', 'RITlug TeleIRC Documentation',
      [author], 1)
 ]
 
@@ -174,8 +174,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'RITlugTeleirc', 'RITlug Teleirc Documentation',
-     author, 'RITlugTeleirc', 'One line description of project.',
+    (master_doc, 'RITlugTeleIRC', 'RITlug TeleIRC Documentation',
+     author, 'RITlugTeleIRC', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/config-file-glossary.rst
+++ b/docs/config-file-glossary.rst
@@ -63,7 +63,7 @@ Telegram settings
     Maximum number of messages sent to Telegram from IRC per minute
 
 ``SHOW_ACTION_MESSAGE=true``
-    Relay action messages (e.g. ``/me thinks Teleirc is cool!``)
+    Relay action messages (e.g. ``/me thinks TeleIRC is cool!``)
 
 ``SHOW_JOIN_MESSAGE=false``
     Send Telegram message when someone joins IRC channel
@@ -91,5 +91,5 @@ Miscellaneous settings
 **********************
 
 ``NTBA_FIX_319=1``
-    Required to fix a bug in a library used by Teleirc.
+    Required to fix a bug in a library used by TeleIRC.
     For context, see `yagop/node-telegram-bot-api#319 <https://github.com/yagop/node-telegram-bot-api/issues/319#issuecomment-324963294>`_.

--- a/docs/deploy-teleirc.rst
+++ b/docs/deploy-teleirc.rst
@@ -1,8 +1,8 @@
 #####################
-How to deploy Teleirc
+How to deploy TeleIRC
 #####################
 
-There are several ways to deploy Teleirc persistently.
+There are several ways to deploy TeleIRC persistently.
 This page offers suggestions on possible deployment options.
 
 
@@ -12,16 +12,16 @@ systemd
 
 The **recommended deployment method** is with `systemd <https://en.wikipedia.org/wiki/Systemd>`_.
 This method requires a basic understanding of systemd unit files.
-Create a unique systemd service for each Teleirc instance.
+Create a unique systemd service for each TeleIRC instance.
 
 A `provided systemd service <https://github.com/RITlug/teleirc/blob/master/misc/teleirc.service>`_ file is available.
 Add the systemd unit file to ``/usr/lib/systemd/system/`` to activate it.
-Now, ``systemctl`` can be used to control your Teleirc instance.
+Now, ``systemctl`` can be used to control your TeleIRC instance.
 
 Note the provided file makes two assumptions:
 
 - Using a dedicated system user (e.g. ``teleirc``)
-- Teleirc config files located at ``/usr/lib64/teleirc/`` (i.e. files inside Teleirc repository)
+- TeleIRC config files located at ``/usr/lib64/teleirc/`` (i.e. files inside TeleIRC repository)
 
 
 ***
@@ -33,7 +33,7 @@ If you run an application and it crashes, pm2 restarts the process.
 pm2 also restarts processes if the server reboots.
 Read the `pm2 documentation <http://pm2.keymetrics.io/docs/usage/quick-start/>`_ for more information.
 
-After pm2 is installed, run these commands to start Teleirc::
+After pm2 is installed, run these commands to start TeleIRC::
 
     cd teleirc/
     pm2 start -n my-teleirc-bot teleirc.js
@@ -44,15 +44,15 @@ Arch Linux AUR
 **************
 
 On ArchLinux, see `teleirc-git <https://aur.archlinux.org/packages/teleirc-git/>`_ in the AUR.
-The AUR package uses the systemd method to deploy Teleirc.
-Place Teleirc configuration files in the ``/usr/lib/teleirc/`` directory.
+The AUR package uses the systemd method to deploy TeleIRC.
+Place TeleIRC configuration files in the ``/usr/lib/teleirc/`` directory.
 
 
 ******
 Docker
 ******
 
-Docker is another way to deploy Teleirc.
+Docker is another way to deploy TeleIRC.
 Dockerfiles and images are available in ``images/``.
 
 Which image do I choose?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -2,7 +2,7 @@
 Frequently asked questions
 ##########################
 
-This page collects frequently asked scenarios or problems with Teleirc.
+This page collects frequently asked scenarios or problems with TeleIRC.
 Did you find something confusing?
 Please let us know in our developer chat or open a new pull request with a suggestion!
 
@@ -18,8 +18,8 @@ Telegram
     Next, send a message in the group with the bot username and refresh the browser window.
     You will see the chat ID for the Telegram group along with other information.
 
-**I reinstalled Teleirc after it was inactive for a while. But the bot doesn't work. Why?**
+**I reinstalled TeleIRC after it was inactive for a while. But the bot doesn't work. Why?**
     If a Telegram bot is not used for a while, it "goes to sleep".
-    Even if Teleirc is configured and installed correctly, you need to "wake up" the bot.
+    Even if TeleIRC is configured and installed correctly, you need to "wake up" the bot.
     To fix this, *remove the bot from the group and add it again*.
-    Restart Teleirc and it should work again.
+    Restart TeleIRC and it should work again.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,12 @@
 ############################
-RITlug Teleirc documentation
+RITlug TeleIRC documentation
 ############################
 
-RITlug Teleirc is a NodeJS implementation of a `Telegram <https://telegram.org/>`_ <=> `IRC <https://en.wikipedia.org/wiki/Internet_Relay_Chat>`_ bridge.
-Teleirc works with any IRC channel and Telegram group.
+RITlug TeleIRC is a NodeJS implementation of a `Telegram <https://telegram.org/>`_ <=> `IRC <https://en.wikipedia.org/wiki/Internet_Relay_Chat>`_ bridge.
+TeleIRC works with any IRC channel and Telegram group.
 It bridges messages between a Telegram group and an IRC channel.
 
-This bot was originally written for `RITlug <http://ritlug.com>`_.
+This bot was originally written for `RITlug <https://ritlug.com>`_.
 Today, it is used by various communities.
 
 .. toctree::

--- a/docs/quick-install.rst
+++ b/docs/quick-install.rst
@@ -2,19 +2,19 @@
 Quick install
 #############
 
-This is a quick installation guide for an administrator to configure and deploy Teleirc.
-Teleirc configuration is divided into these steps:
+This is a quick installation guide for an administrator to configure and deploy TeleIRC.
+TeleIRC configuration is divided into these steps:
 
 #. Create a Telegram bot
 #. Configure IRC channel
-#. Configure and run Teleirc
+#. Configure and run TeleIRC
 
 
 *********************
 Create a Telegram bot
 *********************
 
-.. note:: Teleirc **DOES NOT** support channels, only groups.
+.. note:: TeleIRC **DOES NOT** support channels, only groups.
           Read more about channels vs groups `here <https://telegram.org/faq#q-what-39s-the-difference-between-groups-supergroups-and-channel>`_.
 
 Create a new Telegram bot to act as a bridge from the Telegram side.
@@ -51,10 +51,10 @@ However, there are recommendations for best practices:
 
 
 *************************
-Configure and run Teleirc
+Configure and run TeleIRC
 *************************
 
-This section explains how to configure and install Teleirc itself.
+This section explains how to configure and install TeleIRC itself.
 
 Requirements
 ============
@@ -72,7 +72,7 @@ Install dependencies
 Configuration
 =============
 
-Teleirc uses `dotenv <https://www.npmjs.com/package/dotenv>`_ to manage API keys and settings.
+TeleIRC uses `dotenv <https://www.npmjs.com/package/dotenv>`_ to manage API keys and settings.
 The config file you use is a ``.env`` file.
 Copy the example file to a production file to get started (``cp env.example .env``).
 Edit the ``.env`` file with your API keys and settings.
@@ -84,12 +84,12 @@ Edit the ``.env`` file with your API keys and settings.
 Relay Telegram picture messages via Imgur
 -----------------------------------------
 
-Teleirc retrieves picture messages via the Telegram API.
+TeleIRC retrieves picture messages via the Telegram API.
 By default, picture messages from Telegram are sent to IRC through Imgur.
 `See context <https://github.com/RITlug/teleirc/issues/115>`_ for why Imgur is enabled by default.
 
-.. note:: By default, Teleirc uses the generic Imgur API key.
-          Imgur highly recommends registering each Teleirc bot.
+.. note:: By default, TeleIRC uses the generic Imgur API key.
+          Imgur highly recommends registering each TeleIRC bot.
 
 To add Imgur support, follow these steps:
 
@@ -100,7 +100,7 @@ To add Imgur support, follow these steps:
 
 
 .. [#] @BotFather is the `Telegram bot <https://core.telegram.org/bots>`_ for `creating Telegram bots <https://core.telegram.org/bots#6-botfather>`_
-.. [#] Privacy setting must be disabled for Teleirc bot to see messages in the Telegram group.
+.. [#] Privacy setting must be disabled for TeleIRC bot to see messages in the Telegram group.
        By default, bots cannot see messages unless a person uses a command to interact with the bot.
-       Since Teleirc forwards all messages, it needs to see all messages.
-       Messages are not stored or tracked by Teleirc.
+       Since TeleIRC forwards all messages, it needs to see all messages.
+       Messages are not stored or tracked by TeleIRC.

--- a/docs/who-uses-teleirc.rst
+++ b/docs/who-uses-teleirc.rst
@@ -1,8 +1,8 @@
 #################
-Who uses Teleirc?
+Who uses TeleIRC?
 #################
 
-The following list of projects and communities use RITlug Teleirc:
+The following list of projects and communities use RITlug TeleIRC:
 
 -  `CityZen app <https://cityzenapp.co>`_ (`@CityZenApp <https://t.me/CityZenApp>`_ | `#cityzen <https://webchat.freenode.net/?channels=cityzen>`_)
 
@@ -42,7 +42,7 @@ How to get on this list
 ***********************
 
 Want to have your community added to this page?
-Let us know you're using Teleirc too!
+Let us know you're using TeleIRC too!
 `Submit an issue <https://github.com/RITlug/teleirc/issues/new>`_ against this repo with the following info:
 
 -  Organization / group name and website

--- a/images/README.md
+++ b/images/README.md
@@ -1,4 +1,4 @@
-Using Teleirc with Docker
+Using TeleIRC with Docker
 =========================
 
 The files included here are examples for you to use.

--- a/misc/teleirc.service
+++ b/misc/teleirc.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Teleirc: Telegram + IRC bridge bot
+Description=TeleIRC: Telegram + IRC bridge bot
 Requires=network.target
 After=network.target
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "irc",
     "RITlug"
   ],
-  "author": "Mark Repka, Seth Hendrick, Nate Levesque, Robby O'Connor, Justin W. Flory, RITlug, and Teleirc community",
+  "author": "Mark Repka, Seth Hendrick, Nate Levesque, Robby O'Connor, Justin W. Flory, RITlug, and TeleIRC community",
   "license": "MIT",
   "dependencies": {
     "dotenv": "^2.0.0",

--- a/teleirc.js
+++ b/teleirc.js
@@ -36,4 +36,4 @@ teleIrc.initStage4_addIrcListeners();
 console.log("Enabling Telegram message sending...");
 teleIrc.initStage5_initTelegramMessageSending();
 
-console.log("Setup complete! Teleirc now running.");
+console.log("Setup complete! TeleIRC now running.");


### PR DESCRIPTION
This commit renames all uses of 'Teleirc' in our project to 'TeleIRC'.
This makes the name of our project match the cases of our new logo.
While this is a minor change, it better establishes the project identity
when we go to print materials for things like booth exhibits (e.g.
stickers, brochure hand-outs, etc.).