### PR TITLE
images: Pin Fedora 30 to Fedora Dockerfile

### DIFF
--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM fedora:29
+FROM registry.fedoraproject.org/fedora:30
 
 # Cache layers which will not change
 RUN groupadd teleirc -g 65532 \
@@ -7,8 +7,14 @@ RUN groupadd teleirc -g 65532 \
 COPY . /opt/teleirc/
 WORKDIR /opt/teleirc
 
-RUN dnf -y upgrade --setopt=deltarpm=false \
-    && dnf -y install nodejs nodejs-yarn libicu-devel python gcc-c++ make --setopt=deltarpm=false \
+RUN dnf -y upgrade \
+    && dnf -y install \
+        nodejs \
+        nodejs-yarn \
+        libicu-devel \
+        python \
+        gcc-c++ \
+        make \
     && nodejs-yarn \
     && dnf -y remove libicu-devel gcc-c++ \
     && dnf clean all \


### PR DESCRIPTION
This commit does a couple of things:

* Pins Fedora Dockerfile to Fedora 30
* Switches to use `registry.fedoraproject.org` as the container source
* Splits packages installed across new lines (for readability)

I built this container locally and it worked. Ideally there needs to be
more work to make this viable (e.g. specifying config values as
environment variables), but that is out of scope for this pull request.