### PR TITLE
Reverse #134: Do not render IRC=>Telegram messages as Markdown

### DIFF
--- a/lib/IrcHandlers/IrcMessageHandler.js
+++ b/lib/IrcHandlers/IrcMessageHandler.js
@@ -56,7 +56,7 @@ class IrcMessageHandler {
         );
 
         if (blackListed === false) {
-            let message = "<*" + username + "*> " + userMessage;
+            let message = "<" + username + "> " + userMessage;
             this._action(message);
         }
     }

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -332,7 +332,7 @@ class TeleIrc {
       this.config.tg.maxMessagesPerMinute,
       60,
       (message) => {
-        teleirc.tgbot.sendMessage(teleirc.config.tg.chatId, message, { parse_mode: 'markdown' });
+        teleirc.tgbot.sendMessage(teleirc.config.tg.chatId, message);
       });
 
     this.tgbot.on('message', teleirc.tgEventListener.ParseMessage.bind(teleirc.tgEventListener));


### PR DESCRIPTION
This commit is a partial reversal of the bold username feature
introduced in #134. This disables the Markdown rendering change for
messages sent from IRC to Telegram. Instead of only the username field
being rendered as Markdown, the entire message string is rendered. This
causes some messages to not send over the bridge if incomplete Markdown
is used and also mangles some URLs.

Eventually it would be nice to revisit this, but for now, this fixes a
critical bug at the expense of removing a feature on one half of the
bridge.

---

I also suggest a v1.3.2 bugfix release to follow this PR for the benefit of getting things working again for other users.