### PR TITLE
Fix spacing in edited Telegram message prefix.

### DIFF
--- a/config.js
+++ b/config.js
@@ -18,7 +18,7 @@ let settings = {
     showLeaveMessage: process.env.IRC_SHOW_LEAVE_MESSAGE === "true" || true,
     nickservPassword: process.env.IRC_NICKSERV_PASS || "",
     nickservService: process.env.IRC_NICKSERV_SERVICE || "",
-    editedPrefix: process.env.IRC_EDITED_PREFIX || "[EDIT] ",
+    editedPrefix: process.env.IRC_EDITED_PREFIX || "[EDIT]",
     maxMessageLength: Number(process.env.IRC_MAX_MESSAGE_LENGTH) || 400,
   },
   tg: {

--- a/lib/TelegramHandlers/TgEventListener.js
+++ b/lib/TelegramHandlers/TgEventListener.js
@@ -83,7 +83,7 @@ class TgEventListener extends EventEmitter {
     ParseEditedMessage(msg) {
       if (msg.text) {
         return this.ParseMessage(Object.assign({}, msg, {
-          text: `${this._ircEditPrefix}${msg.text}`
+          text: `${this._ircEditPrefix} ${msg.text}`
         }));
       } else {
         return this.ParseMessage(msg);


### PR DESCRIPTION
This is a super small fix, but it makes sure there is proper spacing between the EDIT prefix and the new Telegram message.