### PR TITLE
Move from Markdown to HTML formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ node_js:
   - 8
   - 10
 
+cache:
+  npm: false
+  yarn: false
+
 addons:
   apt:
     update: true
@@ -20,7 +24,6 @@ script: yarn test
 notifications:
   irc:
     channels:
-      - "ircs://chat.freenode.net:6697/#rit-lug-sysadmin"
       - "ircs://chat.freenode.net:6697/#ritlug-teleirc"
     template:
       - "[%{repository_name}:%{branch}@%{commit} - build #%{build_number}] CI %{result}! (%{build_url})"

--- a/lib/IrcHandlers/IrcMessageHandler.js
+++ b/lib/IrcHandlers/IrcMessageHandler.js
@@ -1,4 +1,5 @@
 const Helpers = require("../Helpers.js");
+const escape = require('escape-html');
 
 /**
  * Handles the event when a user sends a message to the IRC channel.
@@ -56,7 +57,7 @@ class IrcMessageHandler {
         );
 
         if (blackListed === false) {
-            let message = "<*" + username + "*> " + userMessage;
+            let message = "&lt;<b>" + username + "</b>&gt; " + escape(userMessage);
             this._action(message);
         }
     }

--- a/lib/TeleIrc.js
+++ b/lib/TeleIrc.js
@@ -332,7 +332,7 @@ class TeleIrc {
       this.config.tg.maxMessagesPerMinute,
       60,
       (message) => {
-        teleirc.tgbot.sendMessage(teleirc.config.tg.chatId, message, { parse_mode: 'markdown' });
+        teleirc.tgbot.sendMessage(teleirc.config.tg.chatId, message, { parse_mode: 'html' });
       });
 
     this.tgbot.on('message', teleirc.tgEventListener.ParseMessage.bind(teleirc.tgEventListener));

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^2.0.0",
+    "escape-html": "^1.0.3",
     "iconv": "^2.3.1",
     "imgur": "^0.3.1",
     "irc": "~0.5.0",

--- a/tests/IrcConnectionTests.js
+++ b/tests/IrcConnectionTests.js
@@ -179,7 +179,7 @@ exports.IrcConnectionTests = {
     let uut = new TeleIrc(TEST_SETTINGS);
     uut.tgRateLimiter = {
       queueMessage: function(text) {
-        assert.equal(text, `<*${EXPECTED_NICK}*> ${TEST_MESSAGE}`)
+        assert.equal(text, `&lt;<b>${EXPECTED_NICK}</b>&gt; ${TEST_MESSAGE}`)
         assert.done();
       }
     };

--- a/tests/IrcMessageHandlerTests.js
+++ b/tests/IrcMessageHandlerTests.js
@@ -108,7 +108,7 @@ function DoSuccessTest(assert, blackList) {
 
     uut.RelayMessage("User", "#channel", "Hello, World!");
 
-    let expectedMessage = "<*User*> Hello, World!";
+    let expectedMessage = "&lt;<b>User</b>&gt; Hello, World!";
     assert.strictEqual(message, expectedMessage);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -500,6 +500,11 @@ es6-error@^4.0.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
 escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
## What This Does
This PR finally fixes #142, which covers issues we've had with IRC => Telegram markdown support, specifically with sending links that get transformed into markdown, rendering them unclickable Telegram-side. 

The parsing mode moves from markdown to HTML in order to take care of username bolding.


### Possible Issues
Doing HTML parsing may *possibly* cause issues, and so I think we should dig a little more into this before this is merged. However, all the functionality works just as intended, with only usernames being bolded, and links are sending just fine.

### Links
* [HTML Parsing](https://core.telegram.org/bots/api#html-style)
* [sendMessage object](https://core.telegram.org/bots/api#sendmessage)
