### PR TITLE
Resolves #174: Build out config parsing

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/ritlug/teleirc/internal"
+)
+
+func main() {
+	settings, err := internal.LoadConfig("../env.example")
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(settings)
+	}
+}

--- a/env.example
+++ b/env.example
@@ -45,4 +45,4 @@ TELEGRAM_CHAT_ID=-0000000000000
 ###############################################################################
 
 USE_IMGUR_FOR_IMAGES=true
-IMGUR_CLIENT_ID=0000000000
+IMGUR_CLIENT_ID=7d6b00b87043f58

--- a/env.example
+++ b/env.example
@@ -46,14 +46,3 @@ TELEGRAM_CHAT_ID=-0000000000000
 
 USE_IMGUR_FOR_IMAGES=true
 IMGUR_CLIENT_ID=0000000000
-
-
-###############################################################################
-#                                                                             #
-#                      Misc. required env variables                           #
-#                -- not meant for user config, don't touch --                 #
-#                                                                             #
-###############################################################################
-
-# https://github.com/yagop/node-telegram-bot-api/issues/319#issuecomment-324963294
-NTBA_FIX_319=1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/Zedjones/teleirc
 
 go 1.12
+
+require (
+	github.com/caarlos0/env v3.5.0+incompatible
+	github.com/go-playground/locales v0.12.1 // indirect
+	github.com/go-playground/universal-translator v0.16.0 // indirect
+	github.com/go-playground/validator v9.29.1+incompatible
+	github.com/leodido/go-urn v1.1.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Zedjones/teleirc
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Zedjones/teleirc
+module github.com/ritlug/teleirc
 
 go 1.12
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,5 +1,12 @@
 package internal
 
+import (
+	"github.com/caarlos0/env"
+	"github.com/go-playground/validator"
+)
+
+var validate *validator.Validate
+
 // IRCSettings includes settings related to the IRC bot/message relaying
 type IRCSettings struct {
 	Server              string   `env:"IRC_SERVER,required"`
@@ -43,4 +50,19 @@ type Settings struct {
 	IRC      IRCSettings
 	Telegram TelegramSettings
 	Imgur    ImgurSettings
+}
+
+func LoadConfig(path string) error {
+	validate = validator.New()
+	if path == "" {
+		path = ".env"
+	}
+	settings := Settings{}
+	if err := env.Parse(&settings); err != nil {
+		return err
+	}
+	if err := validate.Struct(settings); err != nil {
+		return err.(validator.ValidationErrors)
+	}
+	return nil
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -2,45 +2,45 @@ package internal
 
 // IRCSettings includes settings related to the IRC bot/message relaying
 type IRCSettings struct {
-	Server              string
-	Port                int
-	TLSAllowSelfSigned  bool
-	TLSAllowCertExpired bool
-	Channel             string
-	BotName             string
-	SendStickerEmoji    bool
-	SendDocument        bool
-	Prefix              string
-	Suffix              string
-	ShowJoinMessage     bool
-	ShowLeaveMessage    bool
-	NickServPassword    string
-	NickServService     string
-	EditedPrefix        string
-	MaxMessageLength    int
+	Server              string   `env:"IRC_SERVER,required"`
+	Port                int      `env:"IRC_PORT" envDefault:"6667" validate:"min=0, max=65535"`
+	TLSAllowSelfSigned  bool     `env:"IRC_CERT_ALLOW_SELFSIGNED" envDefault:"true"`
+	TLSAllowCertExpired bool     `env:"IRC_CERT_ALLOW_EXPIRED" envDefault:"true"`
+	Channel             string   `env:"IRC_CHANNEL,required"`
+	BotName             string   `env:"IRC_BOT_NAME" envDefault:"teleirc"`
+	SendStickerEmoji    bool     `env:"IRC_SEND_STICKER_EMOJI" envDefault:"true"`
+	SendDocument        bool     `env:"IRC_SEND_DOCUMENT" envDefault:"true"`
+	Prefix              string   `env:"IRC_PREFIX" envDefault:"<"`
+	Suffix              string   `env:"IRC_SUFFIX" envDefault:">"`
+	ShowJoinMessage     bool     `env:"IRC_SHOW_JOIN_MESSAGE" envDefault:"true"`
+	ShowLeaveMessage    bool     `env:"IRC_SHOW_LEAVE_MESSAGE" envDefault:"true"`
+	NickServPassword    string   `env:"IRC_NICKSERV_PASS" envDefault:""`
+	NickServService     string   `env:"IRC_NICKSERV_SERVICE" envDefault:""`
+	EditedPrefix        string   `env:"IRC_EDITED_PREFIX" envDefault:"[EDIT]"`
+	MaxMessageLength    int      `env:"IRC_EDITED_PREFIX" envDefault:"400"`
+	IRCBlacklist        []string `env:"IRC_BLACKLIST" envDefault:"[]string{}"`
 }
 
 // TelegramSettings includes settings related to the Telegram bot/message relaying
 type TelegramSettings struct {
-	ChatID              string
-	ShowJoinMessage     bool
-	ShowActionMessage   bool
-	ShowLeaveMessage    bool
-	ShowKickMessage     bool
-	MaxMessagePerMinute int
+	ChatID              string `env:"TELEGRAM_CHAT_ID"`
+	ShowJoinMessage     bool   `env:"SHOW_JOIN_MESSAGE"`
+	ShowActionMessage   bool   `env:"SHOW_ACTION_MESSAGE"`
+	ShowLeaveMessage    bool   `env:"SHOW_LEAVE_MESSAGE"`
+	ShowKickMessage     bool   `env:"SHOW_KICK_MESSAGE"`
+	MaxMessagePerMinute int    `env:"MAX_MESSAGE_PER_MINUTE"`
 }
 
 // ImgurSettings includes settings related to Imgur uploading for Telegram photos
 type ImgurSettings struct {
-	UseImgurForImageLinks bool
-	ImgurClientID         string
+	UseImgurForImageLinks bool   `env:"USE_IMGUR_FOR_IMAGE"`
+	ImgurClientID         string `env:"IMGUR_CLIENT_ID"`
 }
 
 // Settings includes all user-configurable settings for TeleIRC
 type Settings struct {
-	Token        string
-	IRCBlacklist []string
-	IRC          IRCSettings
-	Telegram     TelegramSettings
-	Imgur        ImgurSettings
+	Token    string `env:"TELEIRC_TOKEN"`
+	IRC      IRCSettings
+	Telegram TelegramSettings
+	Imgur    ImgurSettings
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -60,11 +60,10 @@ Otherwise, return the error that caused the failure.
 */
 func LoadConfig(path string) (*Settings, error) {
 	validate = validator.New()
-	if path == "" {
-		path = ".env"
-	}
-	if err := godotenv.Load(path); err != nil {
-		return nil, err
+	if path != "" {
+		if err := godotenv.Load(path); err != nil {
+			return nil, err
+		}
 	}
 	settings := Settings{}
 	if err := env.Parse(&settings); err != nil {

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,0 +1,42 @@
+package internal
+
+type IRCSettings struct {
+	Server              string
+	Port                int
+	TLSAllowSelfSigned  bool
+	TLSAllowCertExpired bool
+	Channel             string
+	BotName             string
+	SendStickerEmoji    bool
+	SendDocument        bool
+	Prefix              string
+	Suffix              string
+	ShowJoinMessage     bool
+	ShowLeaveMessage    bool
+	NickServPassword    string
+	NickServService     string
+	EditedPrefix        string
+	MaxMessageLength    int
+}
+
+type TelegramSettings struct {
+	ChatID              string
+	ShowJoinMessage     bool
+	ShowActionMessage   bool
+	ShowLeaveMessage    bool
+	ShowKickMessage     bool
+	MaxMessagePerMinute int
+}
+
+type ImgurSettings struct {
+	UseImgurForImageLinks bool
+	ImgurClientID         string
+}
+
+type Settings struct {
+	Token        string
+	IRCBlacklist []string
+	IRC          IRCSettings
+	Telegram     TelegramSettings
+	Imgur        ImgurSettings
+}

--- a/internal/config.go
+++ b/internal/config.go
@@ -11,7 +11,7 @@ var validate *validator.Validate
 // IRCSettings includes settings related to the IRC bot/message relaying
 type IRCSettings struct {
 	Server              string   `env:"IRC_SERVER,required"`
-	Port                int      `env:"IRC_PORT" envDefault:"6667" validate:"min=0, max=65535"`
+	Port                int      `env:"IRC_PORT" envDefault:"6667" validate:"min=0,max=65535"`
 	TLSAllowSelfSigned  bool     `env:"IRC_CERT_ALLOW_SELFSIGNED" envDefault:"true"`
 	TLSAllowCertExpired bool     `env:"IRC_CERT_ALLOW_EXPIRED" envDefault:"true"`
 	Channel             string   `env:"IRC_CHANNEL,required"`
@@ -25,7 +25,7 @@ type IRCSettings struct {
 	NickServPassword    string   `env:"IRC_NICKSERV_PASS" envDefault:""`
 	NickServService     string   `env:"IRC_NICKSERV_SERVICE" envDefault:""`
 	EditedPrefix        string   `env:"IRC_EDITED_PREFIX" envDefault:"[EDIT]"`
-	MaxMessageLength    int      `env:"IRC_EDITED_PREFIX" envDefault:"400"`
+	MaxMessageLength    int      `env:"IRC_MAX_MESSAGE_LENGTH" envDefault:"400"`
 	IRCBlacklist        []string `env:"IRC_BLACKLIST" envDefault:"[]string{}"`
 }
 
@@ -70,7 +70,7 @@ func LoadConfig(path string) (*Settings, error) {
 	if err := env.Parse(&settings); err != nil {
 		return nil, err
 	}
-	if err := validate.Struct(settings); err != nil {
+	if err := validate.Struct(&settings); err != nil {
 		return nil, err.(validator.ValidationErrors)
 	}
 	return &settings, nil

--- a/internal/config.go
+++ b/internal/config.go
@@ -52,17 +52,22 @@ type Settings struct {
 	Imgur    ImgurSettings
 }
 
-func LoadConfig(path string) error {
+/*
+LoadConfig loads in the .env file in the provided path (or ".env" by default)
+If the user-provided config is valid, return a new Settings struct that contains these settings.
+Otherwise, return the error that caused the failure.
+*/
+func LoadConfig(path string) (*Settings, error) {
 	validate = validator.New()
 	if path == "" {
 		path = ".env"
 	}
 	settings := Settings{}
 	if err := env.Parse(&settings); err != nil {
-		return err
+		return nil, err
 	}
 	if err := validate.Struct(settings); err != nil {
-		return err.(validator.ValidationErrors)
+		return nil, err.(validator.ValidationErrors)
 	}
-	return nil
+	return &settings, nil
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -65,6 +65,7 @@ func LoadConfig(path string) (*Settings, error) {
 			return nil, err
 		}
 	}
+	// TODO: Check to see if the default path exists and try to load it if it does
 	settings := Settings{}
 	if err := env.Parse(&settings); err != nil {
 		return nil, err

--- a/internal/config.go
+++ b/internal/config.go
@@ -23,23 +23,23 @@ type IRCSettings struct {
 
 // TelegramSettings includes settings related to the Telegram bot/message relaying
 type TelegramSettings struct {
-	ChatID              string `env:"TELEGRAM_CHAT_ID"`
-	ShowJoinMessage     bool   `env:"SHOW_JOIN_MESSAGE"`
-	ShowActionMessage   bool   `env:"SHOW_ACTION_MESSAGE"`
-	ShowLeaveMessage    bool   `env:"SHOW_LEAVE_MESSAGE"`
-	ShowKickMessage     bool   `env:"SHOW_KICK_MESSAGE"`
-	MaxMessagePerMinute int    `env:"MAX_MESSAGE_PER_MINUTE"`
+	ChatID              string `env:"TELEGRAM_CHAT_ID,required"`
+	ShowJoinMessage     bool   `env:"SHOW_JOIN_MESSAGE" envDefault:"false"`
+	ShowActionMessage   bool   `env:"SHOW_ACTION_MESSAGE" envDefault:"false"`
+	ShowLeaveMessage    bool   `env:"SHOW_LEAVE_MESSAGE" envDefault:"false"`
+	ShowKickMessage     bool   `env:"SHOW_KICK_MESSAGE" envDefault:"false"`
+	MaxMessagePerMinute int    `env:"MAX_MESSAGE_PER_MINUTE" envDefault:"20"`
 }
 
 // ImgurSettings includes settings related to Imgur uploading for Telegram photos
 type ImgurSettings struct {
-	UseImgurForImageLinks bool   `env:"USE_IMGUR_FOR_IMAGE"`
-	ImgurClientID         string `env:"IMGUR_CLIENT_ID"`
+	UseImgurForImageLinks bool   `env:"USE_IMGUR_FOR_IMAGE" envDefault:"true"`
+	ImgurClientID         string `env:"IMGUR_CLIENT_ID" envDefault:"12345"`
 }
 
 // Settings includes all user-configurable settings for TeleIRC
 type Settings struct {
-	Token    string `env:"TELEIRC_TOKEN"`
+	Token    string `env:"TELEIRC_TOKEN,required"`
 	IRC      IRCSettings
 	Telegram TelegramSettings
 	Imgur    ImgurSettings

--- a/internal/config.go
+++ b/internal/config.go
@@ -28,7 +28,7 @@ type IRCSettings struct {
 	ShowLeaveMessage    bool     `env:"IRC_SHOW_LEAVE_MESSAGE" envDefault:"true"`
 	NickServPassword    string   `env:"IRC_NICKSERV_PASS" envDefault:""`
 	NickServService     string   `env:"IRC_NICKSERV_SERVICE" envDefault:""`
-	EditedPrefix        string   `env:"IRC_EDITED_PREFIX" envDefault:"[EDIT]"`
+	EditedPrefix        string   `env:"IRC_EDITED_PREFIX" envDefault:"[EDIT] "`
 	MaxMessageLength    int      `env:"IRC_MAX_MESSAGE_LENGTH" envDefault:"400"`
 	IRCBlacklist        []string `env:"IRC_BLACKLIST" envDefault:"[]string{}"`
 }
@@ -46,7 +46,7 @@ type TelegramSettings struct {
 // ImgurSettings includes settings related to Imgur uploading for Telegram photos
 type ImgurSettings struct {
 	UseImgurForImageLinks bool   `env:"USE_IMGUR_FOR_IMAGE" envDefault:"true"`
-	ImgurClientID         string `env:"IMGUR_CLIENT_ID" envDefault:"12345"`
+	ImgurClientID         string `env:"IMGUR_CLIENT_ID" envDefault:"7d6b00b87043f58"`
 }
 
 // Settings includes all user-configurable settings for TeleIRC

--- a/internal/config.go
+++ b/internal/config.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"github.com/caarlos0/env"
 	"github.com/go-playground/validator"
+	"github.com/joho/godotenv"
 )
 
 var validate *validator.Validate
@@ -61,6 +62,9 @@ func LoadConfig(path string) (*Settings, error) {
 	validate = validator.New()
 	if path == "" {
 		path = ".env"
+	}
+	if err := godotenv.Load(path); err != nil {
+		return nil, err
 	}
 	settings := Settings{}
 	if err := env.Parse(&settings); err != nil {

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,12 +1,16 @@
 package internal
 
 import (
+	"os"
+
 	"github.com/caarlos0/env"
 	"github.com/go-playground/validator"
 	"github.com/joho/godotenv"
 )
 
 var validate *validator.Validate
+
+const defaultPath = ".env"
 
 // IRCSettings includes settings related to the IRC bot/message relaying
 type IRCSettings struct {
@@ -60,12 +64,17 @@ Otherwise, return the error that caused the failure.
 */
 func LoadConfig(path string) (*Settings, error) {
 	validate = validator.New()
+	// Attempt to load environment variables from path if path was provided
 	if path != "" {
 		if err := godotenv.Load(path); err != nil {
 			return nil, err
 		}
+	} else if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
+		// Attempt to load from defaultPath is defaultPath exists
+		if err := godotenv.Load(defaultPath); err != nil {
+			return nil, err
+		}
 	}
-	// TODO: Check to see if the default path exists and try to load it if it does
 	settings := Settings{}
 	if err := env.Parse(&settings); err != nil {
 		return nil, err

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,5 +1,6 @@
 package internal
 
+// IRCSettings includes settings related to the IRC bot/message relaying
 type IRCSettings struct {
 	Server              string
 	Port                int
@@ -19,6 +20,7 @@ type IRCSettings struct {
 	MaxMessageLength    int
 }
 
+// TelegramSettings includes settings related to the Telegram bot/message relaying
 type TelegramSettings struct {
 	ChatID              string
 	ShowJoinMessage     bool
@@ -28,11 +30,13 @@ type TelegramSettings struct {
 	MaxMessagePerMinute int
 }
 
+// ImgurSettings includes settings related to Imgur uploading for Telegram photos
 type ImgurSettings struct {
 	UseImgurForImageLinks bool
 	ImgurClientID         string
 }
 
+// Settings includes all user-configurable settings for TeleIRC
 type Settings struct {
 	Token        string
 	IRCBlacklist []string


### PR DESCRIPTION
This PR adds initial config parsing to the Go port, as well as removes an unneeded section from the `env.example` file that was related to a bug in a Node.js library. 

No testing was added at the moment due to indecision on how exactly we want to test the code.