### PR TITLE
issue templates: Change label 'discussion' -> 'needs triage'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report to help us improve
 title: ''
-labels: bug, discussion
+labels: bug, needs triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/improvement-to-existing-functionality.md
+++ b/.github/ISSUE_TEMPLATE/improvement-to-existing-functionality.md
@@ -2,7 +2,7 @@
 name: Improvement to existing functionality
 about: Suggest an improvement to something that already exists
 title: ''
-labels: discussion, improvement
+labels: improvement, needs triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/new-feature-request.md
@@ -2,7 +2,7 @@
 name: New feature request
 about: Suggest a new idea for this project
 title: ''
-labels: discussion, new change
+labels: needs triage, new change
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -2,7 +2,7 @@
 name: Other
 about: Something that doesn't belong elsewhere
 title: ''
-labels: discussion
+labels: needs triage
 assignees: ''
 
 ---


### PR DESCRIPTION
This commit is a nitpick, but I changed the `discussion` label to
`needs triage`. I think `needs triage` inspires action to decide if a
new issue is accepted for development or not. "Discussion" is broad and
open-ended, and anything can be discussed for about as long as you like.
So, I figure `needs triage` is more direct with the intent that a new
issue needs to be considered or reviewed before it is accepted to the
development backlog.