### PR TITLE
Telegram unit tests and explicit dependency ordering

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -38,12 +38,7 @@ func main() {
 		return
 	}
 
-	tgClient, err := tg.NewClient(settings.Telegram)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
+	tgClient := tg.NewClient(settings.Telegram)
 	tgChan := make(chan error)
 	go tgClient.StartBot(tgChan)
 

--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ritlug/teleirc/internal"
 	"github.com/ritlug/teleirc/internal/handlers/irc"
 	tg "github.com/ritlug/teleirc/internal/handlers/telegram"
@@ -32,13 +33,13 @@ func main() {
 	}
 
 	settings, err := internal.LoadConfig(*flagPath)
-
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	tgClient := tg.NewClient(settings.Telegram)
+	var tgapi *tgbotapi.BotAPI
+	tgClient := tg.NewClient(settings.Telegram, tgapi)
 	tgChan := make(chan error)
 	go tgClient.StartBot(tgChan)
 

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -20,9 +20,9 @@ type Client struct {
 /*
 NewClient creates a new Telegram bot client
 */
-func NewClient(settings internal.TelegramSettings) *Client {
+func NewClient(settings internal.TelegramSettings, tgapi *tgbotapi.BotAPI) *Client {
 	fmt.Println("Creating new Telegram bot client...")
-	return &Client{Settings: settings}
+	return &Client{api: tgapi, Settings: settings}
 }
 
 /*

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -20,14 +20,9 @@ type Client struct {
 /*
 NewClient creates a new Telegram bot client
 */
-func NewClient(settings internal.TelegramSettings) (Client, error) {
+func NewClient(settings internal.TelegramSettings) *Client {
 	fmt.Println("Creating new Telegram bot client...")
-	bot, err := tgbotapi.NewBotAPI(settings.Token)
-	if err != nil {
-		fmt.Println("Error creating Telegram client")
-		return Client{}, err
-	}
-	return Client{bot, settings}, nil
+	return &Client{Settings: settings}
 }
 
 /*
@@ -36,6 +31,12 @@ returning any errors that occur
 */
 func (tg *Client) StartBot(errChan chan<- error) {
 	fmt.Println("Starting up Telegram bot...")
+	var err error
+	tg.api, err = tgbotapi.NewBotAPI(tg.Settings.Token)
+	if err != nil {
+		fmt.Println("Failed to connect to Telegram")
+		errChan <- err
+	}
 	u := tgbotapi.NewUpdate(0)
 	u.Timeout = 60
 

--- a/internal/handlers/telegram/telegram_test.go
+++ b/internal/handlers/telegram/telegram_test.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"testing"
 
+	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ritlug/teleirc/internal"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +13,8 @@ func TestNewClientBasic(t *testing.T) {
 		Token:  "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
 		ChatID: "-0000000000000",
 	}
-	client := NewClient(tgSettings)
+	var tgapi *tgbotapi.BotAPI
+	client := NewClient(tgSettings, tgapi)
 	assert.Equal(t, client.Settings, tgSettings, "Basic client settings should be properly set")
 }
 
@@ -26,6 +28,7 @@ func TestNewClientFull(t *testing.T) {
 		ShowKickMessage:     true,
 		MaxMessagePerMinute: 10,
 	}
-	client := NewClient(tgSettings)
+	var tgapi *tgbotapi.BotAPI
+	client := NewClient(tgSettings, tgapi)
 	assert.Equal(t, client.Settings, tgSettings, "All client settings should be properly set")
 }

--- a/internal/handlers/telegram/telegram_test.go
+++ b/internal/handlers/telegram/telegram_test.go
@@ -13,6 +13,19 @@ func TestNewClientBasic(t *testing.T) {
 		ChatID: "-0000000000000",
 	}
 	client := NewClient(tgSettings)
+	assert.Equal(t, client.Settings, tgSettings, "Basic client settings should be properly set")
+}
 
-	assert.Equal(t, client.Settings, tgSettings, "Client settings should be properly set")
+func TestNewClientFull(t *testing.T) {
+	tgSettings := internal.TelegramSettings{
+		Token:               "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
+		ChatID:              "-0000000000000",
+		ShowJoinMessage:     true,
+		ShowActionMessage:   true,
+		ShowLeaveMessage:    true,
+		ShowKickMessage:     true,
+		MaxMessagePerMinute: 10,
+	}
+	client := NewClient(tgSettings)
+	assert.Equal(t, client.Settings, tgSettings, "All client settings should be properly set")
 }

--- a/internal/handlers/telegram/telegram_test.go
+++ b/internal/handlers/telegram/telegram_test.go
@@ -1,0 +1,18 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/ritlug/teleirc/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClientBasic(t *testing.T) {
+	tgSettings := internal.TelegramSettings{
+		Token:  "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
+		ChatID: "-0000000000000",
+	}
+	client := NewClient(tgSettings)
+
+	assert.Equal(t, client.Settings, tgSettings, "Client settings should be properly set")
+}


### PR DESCRIPTION
# PR Overview
This PR hopes to address the explicit dependencies issue from the Telegram side, and adds unit tests to verify a new Telegram client is properly created with the given config settings.

## PR Specifics
* Moves client connection into `StartBot()`
* Sets Telegram client API key from the Client struct, and not from the outside library itself
* Creates unit tests to make sure the client is properly set up with the correct, given settings

## Other Notes
With these unit tests done, I don't believe there is a reason to implement unit tests directly on the `cmd/teleirc.go`. So, with the IRC and Telegram base unit tests done, this PR closes #191.