### PR TITLE
docs: Update IRC channel (#ritlug-teleirc -> #rit-lug-teleirc)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
 notifications:
   irc:
     channels:
-      - "ircs://chat.freenode.net:6697/#ritlug-teleirc"
+      - "ircs://chat.freenode.net:6697/#rit-lug-teleirc"
     template:
       - "[%{repository_name}:%{branch}@%{commit} - build #%{build_number}] CI %{result}! (%{build_url})"
     on_success: change

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A public Telegram supergroup and IRC channel (on Freenode) are available for tes
 Our developer community is found in these channels.
 
 * **[Telegram](https://t.me/teleirc)**
-* **[IRC](https://webchat.freenode.net/?channels=ritlug-teleirc)** (#ritlug-teleirc @ irc.freenode.net)
+* **[IRC](https://webchat.freenode.net/?channels=rit-lug-teleirc)** (#rit-lug-teleirc @ irc.freenode.net)
 
 
 ## Contribute to TeleIRC

--- a/docs/about/who-uses-teleirc.rst
+++ b/docs/about/who-uses-teleirc.rst
@@ -35,8 +35,8 @@ The following list of projects and communities use RITlug TeleIRC:
 
 -  `Pure Data <https://puredata.info/>`_ (`@puredata <https://t.me/puredata>`_ | `#dataflow <https://webchat.freenode.net/?channels=dataflow>`_)
 
--  `RITlug <https://ritlug.com>`_ (`@ritlug <https://t.me/ritlug>`_ | `#ritlug <https://webchat.freenode.net/?channels=ritlug>`_)
-    -  `RITlug teleirc <https://github.com/RITlug/teleirc>`_ (`@teleirc <https://t.me/teleirc>`_ | `#ritlug-teleirc <https://webchat.freenode.net/?channels=ritlug-teleirc>`_)
+-  `RITlug <https://ritlug.com>`_ (`@ritlug <https://t.me/ritlug>`_ | `#rit-lug <https://webchat.freenode.net/?channels=rit-lug>`_)
+    -  `RITlug teleirc <https://github.com/RITlug/teleirc>`_ (`@teleirc <https://t.me/teleirc>`_ | `#rit-lug-teleirc <https://webchat.freenode.net/?channels=rit-lug-teleirc>`_)
 
 
 ***********************

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -81,7 +81,7 @@ Stick to the guidelines for quicker and easier pull request reviews.
 
 Project maintainers are committed to **no more than 10 days for a reply** to a new ticket.
 Current maintainers are volunteers working on the project, so we try to keep up with the project as best we can.
-If more than 10 days passed and you have not received a reply, follow up in [Telegram](https://t.me/teleirc) or [IRC](https://webchat.freenode.net/?channels=ritlug-teleirc) (`#ritlug-teleirc` on irc.freenode.net).
+If more than 10 days passed and you have not received a reply, follow up in [Telegram](https://t.me/teleirc) or [IRC](https://webchat.freenode.net/?channels=rit-lug-teleirc) (`#rit-lug-teleirc` on irc.freenode.net).
 Someone may have missed your comment – we are not intentionally ignoring anyone.
 
 _Remember_, using issue templates and answering the above questions in new pull requests likely reduces response time from a maintainer to your ticket / PR.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ A public Telegram supergroup and IRC channel (on Freenode) are available for tes
 Our developer community is found in these channels.
 
 - Telegram: `@teleirc <https://telegram.me/teleirc>`_
-- IRC: `#ritlug-teleirc <https://webchat.freenode.net/?channels=ritlug-teleirc>`_ (chat.freenode.net)
+- IRC: `#rit-lug-teleirc <https://webchat.freenode.net/?channels=rit-lug-teleirc>`_ (chat.freenode.net)
 
 
 ******************


### PR DESCRIPTION
This updates our IRC channel name to direct people into the correct IRC
channel for getting help and support.