### PR TITLE
Lay groundwork for unified message handling between IRC <=> Telegram

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -36,7 +36,7 @@ type IRCSettings struct {
 // TelegramSettings includes settings related to the Telegram bot/message relaying
 type TelegramSettings struct {
 	Token               string `env:"TELEIRC_TOKEN,required"`
-	ChatID              string `env:"TELEGRAM_CHAT_ID,required"`
+	ChatID              int64  `env:"TELEGRAM_CHAT_ID,required"`
 	ShowJoinMessage     bool   `env:"SHOW_JOIN_MESSAGE" envDefault:"false"`
 	ShowActionMessage   bool   `env:"SHOW_ACTION_MESSAGE" envDefault:"false"`
 	ShowLeaveMessage    bool   `env:"SHOW_LEAVE_MESSAGE" envDefault:"false"`

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -26,6 +26,16 @@ func NewClient(settings internal.TelegramSettings, tgapi *tgbotapi.BotAPI) *Clie
 }
 
 /*
+SendMessage sends a message to the Telegram channel specified in the settings
+*/
+func (tg *Client) SendMessage(msg string) {
+	// TODO: Figure out how to properly format an IRC message
+	newMsg := tgbotapi.NewMessage(tg.Settings.ChatID, "")
+	newMsg.Text = msg
+	tg.api.Send(newMsg)
+}
+
+/*
 StartBot adds necessary handlers to the client and then connects,
 returning any errors that occur
 */
@@ -50,10 +60,14 @@ func (tg *Client) StartBot(errChan chan<- error) {
 		if update.Message == nil {
 			continue
 		}
-		// Repeat sent message back to user
-		msg := tgbotapi.NewMessage(update.Message.Chat.ID, update.Message.Text)
-		fmt.Println("Sending message:", msg)
-		tg.api.Send(msg)
+		//formatted := "<" + update.Message.From + "> " + update.Message.Text
+		//fmt.Println("Sending message:", update.Message.Text)
+		//tg.SendMessage(formatted)
+
+		// TODO: this info goes into the IRC sendMessage handler
+		newMsg := tgbotapi.NewMessage(tg.Settings.ChatID, "")
+		newMsg.Text = "<" + update.Message.From.UserName + "> " + update.Message.Text
+		tg.api.Send(newMsg)
 	}
 	errChan <- nil
 }

--- a/internal/handlers/telegram/telegram_test.go
+++ b/internal/handlers/telegram/telegram_test.go
@@ -11,7 +11,7 @@ import (
 func TestNewClientBasic(t *testing.T) {
 	tgSettings := internal.TelegramSettings{
 		Token:  "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
-		ChatID: "-0000000000000",
+		ChatID: -0000000000000,
 	}
 	var tgapi *tgbotapi.BotAPI
 	client := NewClient(tgSettings, tgapi)
@@ -21,7 +21,7 @@ func TestNewClientBasic(t *testing.T) {
 func TestNewClientFull(t *testing.T) {
 	tgSettings := internal.TelegramSettings{
 		Token:               "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
-		ChatID:              "-0000000000000",
+		ChatID:              -0000000000000,
 		ShowJoinMessage:     true,
 		ShowActionMessage:   true,
 		ShowLeaveMessage:    true,

--- a/internal/handlers/telegram/telegram_test.go
+++ b/internal/handlers/telegram/telegram_test.go
@@ -3,19 +3,28 @@ package telegram
 import (
 	"testing"
 
-	"github.com/go-telegram-bot-api/telegram-bot-api"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ritlug/teleirc/internal"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewClientBasic(t *testing.T) {
-	tgSettings := internal.TelegramSettings{
+	tgRequiredSettings := internal.TelegramSettings{
 		Token:  "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
 		ChatID: -0000000000000,
 	}
+	tgExpectedSettings := internal.TelegramSettings{
+		Token:               "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
+		ChatID:              -0000000000000,
+		ShowJoinMessage:     false,
+		ShowActionMessage:   false,
+		ShowLeaveMessage:    false,
+		ShowKickMessage:     false,
+		MaxMessagePerMinute: 0,
+	}
 	var tgapi *tgbotapi.BotAPI
-	client := NewClient(tgSettings, tgapi)
-	assert.Equal(t, client.Settings, tgSettings, "Basic client settings should be properly set")
+	client := NewClient(tgRequiredSettings, tgapi)
+	assert.Equal(t, client.Settings, tgExpectedSettings, "Basic client settings should be properly set")
 }
 
 func TestNewClientFull(t *testing.T) {
@@ -28,7 +37,17 @@ func TestNewClientFull(t *testing.T) {
 		ShowKickMessage:     true,
 		MaxMessagePerMinute: 10,
 	}
+	tgDefaultSettings := internal.TelegramSettings{
+		Token:               "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
+		ChatID:              -0000000000000,
+		ShowJoinMessage:     false,
+		ShowActionMessage:   false,
+		ShowLeaveMessage:    false,
+		ShowKickMessage:     false,
+		MaxMessagePerMinute: 0,
+	}
 	var tgapi *tgbotapi.BotAPI
 	client := NewClient(tgSettings, tgapi)
 	assert.Equal(t, client.Settings, tgSettings, "All client settings should be properly set")
+	assert.NotEqual(t, client.Settings, tgDefaultSettings, "tgSettings should override defaults")
 }


### PR DESCRIPTION
## What This PR Does
* Creates basic `sendMessage` function
* Outlines general structure required to send messages to another platform
  * Includes commented-out code making use of the `sendMessage` func and structure
* changes `ChatID` Telegram option to `int64` datatype
* Fixes Telegram unit tests not correctly testing against full settings


## Next Steps
Flip `sendMessage` functions between Telegram/IRC so Telegram uses IRC's `sendMessage` to send messages over to IRC, and vice versa. 