### PR TITLE
fmt print statements replaced using the log package

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -3,8 +3,9 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
+	"log"
+	"io/ioutil"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ritlug/teleirc/internal"
@@ -20,24 +21,30 @@ var (
 	flagPath    = flag.String("conf", ".env", "config file")
 	flagDebug   = flag.Bool("debug", false, "enable debugging")
 	flagVersion = flag.Bool("version", false, "displays current version of TeleIRC")
+
+	logFlags    = log.Ldate | log.Ltime | log.Lmicroseconds | log.Llongfile
+	Info        = log.New(os.Stdout, "INFO: ", logFlags)
+	Warning     = log.New(os.Stdout, "WARNING: ", logFlags)
+	Error       = log.New(os.Stderr, "ERROR: ", logFlags)
+	Ignored     = log.New(ioutil.Discard, "ERROR: ", logFlags)
 )
 
 func main() {
 	flag.Parse()
 
 	if *flagVersion {
-		fmt.Printf("Current TeleIRC version: %s\n", version)
+		Info.Printf("Current TeleIRC version: %s\n", version)
 		return
 	}
 
 	// TODO: Build out debugging capabilities for more verbose output
 	if *flagDebug {
-		fmt.Printf("Debug mode currently set to: %t\n", *flagDebug)
+		Info.Printf("Debug mode currently set to: %t\n", *flagDebug)
 	}
 
 	settings, err := internal.LoadConfig(*flagPath)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		Error.Println(err)
 		os.Exit(1)
 	}
 
@@ -52,8 +59,8 @@ func main() {
 
 	select {
 	case ircErr := <-ircChan:
-		fmt.Println(ircErr)
+		Error.Println(ircErr)
 	case tgErr := <-tgChan:
-		fmt.Println(tgErr)
+		Error.Println(tgErr)
 	}
 }

--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -24,7 +24,7 @@ var (
 func main() {
 	flag.Parse()
 
-	verbose := internal.Debug {DebugLevel:  *flagDebug	}
+	verbose := internal.Debug { DebugLevel:  *flagDebug }
 
 	if *flagVersion {
 		verbose.PrintVersion("Current TeleIRC version: " + version)

--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -27,7 +27,7 @@ func main() {
 	verbose := internal.Debug { *flagDebug	}
 
 	if *flagVersion {
-		verbose.LogInfo("Current TeleIRC version: " + version)
+		verbose.PrintVersion("Current TeleIRC version: " + version)
 		return
 	}
 

--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -24,9 +24,7 @@ var (
 
 	logFlags    = log.Ldate | log.Ltime | log.Lmicroseconds | log.Llongfile
 	Info        = log.New(os.Stdout, "INFO: ", logFlags)
-	Warning     = log.New(os.Stdout, "WARNING: ", logFlags)
 	Error       = log.New(os.Stderr, "ERROR: ", logFlags)
-	Ignored     = log.New(ioutil.Discard, "ERROR: ", logFlags)
 )
 
 func main() {

--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -24,7 +24,7 @@ var (
 func main() {
 	flag.Parse()
 
-	verbose := internal.Debug { *flagDebug	}
+	verbose := internal.Debug {DebugLevel:  *flagDebug	}
 
 	if *flagVersion {
 		verbose.PrintVersion("Current TeleIRC version: " + version)

--- a/internal/debug.go
+++ b/internal/debug.go
@@ -36,3 +36,7 @@ func (d Debug) LogWarning(message string) {
 		warning.Println(message)
 	}
 }
+
+func (d Debug) PrintVersion(message string) {
+	info.Println(message)
+}

--- a/internal/debug.go
+++ b/internal/debug.go
@@ -17,6 +17,14 @@ var (
 	warning     = log.New(os.Stderr, "WARNING: ", logFlags)
 )
 
+
+type DebugLogger interface {
+	LogInfo(string)
+	LogError(error)
+	LogWarning(string)
+	PrintVersion(string)
+}
+
 type Debug struct {
 	DebugLevel  bool
 }

--- a/internal/debug.go
+++ b/internal/debug.go
@@ -1,0 +1,38 @@
+/*
+	Debug contains information about debug levels and define
+	debug statements
+*/
+package internal
+
+import (
+	"log"
+	"os"
+)
+
+var (
+	// logFlags    = log.Ldate | log.Ltime | log.Lshortfile
+	logFlags    = log.Ldate | log.Ltime
+	info = log.New(os.Stdout, "INFO: ", logFlags)
+	errorLog    = log.New(os.Stderr, "ERROR: ", logFlags)
+	warning     = log.New(os.Stderr, "WARNING: ", logFlags)
+)
+
+type Debug struct {
+	DebugLevel  bool
+}
+
+func (d Debug) LogInfo(message string) {
+	if d.DebugLevel {
+		info.Println(message)
+	}
+}
+
+func (d Debug) LogError(message error) {
+	errorLog.Println(message)
+}
+
+func (d Debug) LogWarning(message string) {
+	if d.DebugLevel {
+		warning.Println(message)
+	}
+}

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -13,14 +13,14 @@ and the IRCSettings that were passed into NewClient
 type Client struct {
 	*girc.Client
 	Settings internal.IRCSettings
-	verbose internal.Debug
+	verbose internal.DebugLogger
 	sendToTg func(string)
 }
 
 /*
 NewClient returns a new IRCClient based on the provided settings
 */
-func NewClient(settings internal.IRCSettings, debug internal.Debug) Client {
+func NewClient(settings internal.IRCSettings, debug internal.DebugLogger) Client {
 	debug.LogInfo("Creating new IRC bot client...")
 	client := girc.New(girc.Config{
 		Server: settings.Server,

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -24,9 +24,7 @@ Creating variables for logging
 var (
 	logFlags    = log.Ldate | log.Ltime | log.Lmicroseconds | log.Llongfile
 	Info        = log.New(os.Stdout, "INFO: ", logFlags)
-	Warning     = log.New(os.Stdout, "WARNING: ", logFlags)
 	Error       = log.New(os.Stderr, "ERROR: ", logFlags)
-	Ignored     = log.New(ioutil.Discard, "ERROR: ", logFlags)
 )
 
 /*
@@ -59,6 +57,7 @@ func (c Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 	c.addHandlers()
 	if err := c.Connect(); err != nil {
 		errChan <- err
+		Error.Println(err)
 	} else {
 		errChan <- nil
 	}

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -1,7 +1,8 @@
 package irc
 
 import (
-	"fmt"
+	"log"
+	"io/ioutil"
 
 	"github.com/lrstanley/girc"
 	"github.com/ritlug/teleirc/internal"
@@ -18,10 +19,21 @@ type Client struct {
 }
 
 /*
+Creating variables for logging
+*/
+var (
+	logFlags    = log.Ldate | log.Ltime | log.Lmicroseconds | log.Llongfile
+	Info        = log.New(os.Stdout, "INFO: ", logFlags)
+	Warning     = log.New(os.Stdout, "WARNING: ", logFlags)
+	Error       = log.New(os.Stderr, "ERROR: ", logFlags)
+	Ignored     = log.New(ioutil.Discard, "ERROR: ", logFlags)
+)
+
+/*
 NewClient returns a new IRCClient based on the provided settings
 */
 func NewClient(settings internal.IRCSettings) Client {
-	fmt.Println("Creating new IRC bot client...")
+	Info.Println("Creating new IRC bot client...")
 	client := girc.New(girc.Config{
 		Server: settings.Server,
 		Port:   settings.Port,
@@ -42,7 +54,7 @@ StartBot adds necessary handlers to the client and then connects,
 returns any errors that occur
 */
 func (c Client) StartBot(errChan chan<- error, sendMessage func(string)) {
-	fmt.Println("Starting up IRC bot...")
+	Info.Println("Starting up IRC bot...")
 	c.sendToTg = sendMessage
 	c.addHandlers()
 	if err := c.Connect(); err != nil {
@@ -65,7 +77,7 @@ addHandlers adds handlers for the client struct based on the settings
 that were passed in to NewClient
 */
 func (c Client) addHandlers() {
-	fmt.Println("Adding IRC event handlers...")
+	Info.Println("Adding IRC event handlers...")
 	for eventType, handler := range getHandlerMapping() {
 		c.Handlers.Add(eventType, handler(c))
 	}

--- a/internal/handlers/irc/irc_test.go
+++ b/internal/handlers/irc/irc_test.go
@@ -15,7 +15,10 @@ func TestNewClientBasic(t *testing.T) {
 		Port:    1234,
 		BotName: "test_name",
 	}
-	client := NewClient(ircSettings)
+	logger := internal.Debug{
+		DebugLevel:  false,
+	}
+	client := NewClient(ircSettings, logger)
 
 	expectedPing, _ := time.ParseDuration("20s")
 	expectedConfig := girc.Config{
@@ -36,7 +39,10 @@ func TestNewClientFull(t *testing.T) {
 		BotName:          "test_name",
 		NickServPassword: "test_pass",
 	}
-	client := NewClient(ircSettings)
+	logger := internal.Debug{
+		DebugLevel:  false,
+	}
+	client := NewClient(ircSettings, logger)
 	expectedPing, _ := time.ParseDuration("20s")
 	expectedConfig := girc.Config{
 		Server:    "test_server",

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -25,9 +25,7 @@ Creating variables for logging
 var (
 	logFlags    = log.Ldate | log.Ltime | log.Lmicroseconds | log.Llongfile
 	Info        = log.New(os.Stdout, "INFO: ", logFlags)
-	Warning     = log.New(os.Stdout, "WARNING: ", logFlags)
 	Error       = log.New(os.Stderr, "ERROR: ", logFlags)
-	Ignored     = log.New(ioutil.Discard, "ERROR: ", logFlags)
 )
 
 /*
@@ -67,6 +65,7 @@ func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 	updates, err := tg.api.GetUpdatesChan(u)
 	if err != nil {
 		errChan <- err
+		Error.Println(err)
 	}
 
 	// TODO: Move these lines into the updateHandler when available

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -14,14 +14,14 @@ the TelegramSettings needed to run the bot
 type Client struct {
 	api       *tgbotapi.BotAPI
 	Settings  internal.TelegramSettings
-	verbose   internal.Debug
+	verbose   internal.DebugLogger
 	sendToIrc func(string)
 }
 
 /*
 NewClient creates a new Telegram bot client
 */
-func NewClient(settings internal.TelegramSettings, tgapi *tgbotapi.BotAPI, debug internal.Debug) *Client {
+func NewClient(settings internal.TelegramSettings, tgapi *tgbotapi.BotAPI, debug internal.DebugLogger) *Client {
 	debug.LogInfo("Creating new Telegram bot client...")
 	return &Client{api: tgapi, Settings: settings, verbose: debug}
 }

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -2,7 +2,8 @@
 package telegram
 
 import (
-	"fmt"
+	"log"
+	"io/ioutil"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ritlug/teleirc/internal"
@@ -19,10 +20,21 @@ type Client struct {
 }
 
 /*
+Creating variables for logging
+*/
+var (
+	logFlags    = log.Ldate | log.Ltime | log.Lmicroseconds | log.Llongfile
+	Info        = log.New(os.Stdout, "INFO: ", logFlags)
+	Warning     = log.New(os.Stdout, "WARNING: ", logFlags)
+	Error       = log.New(os.Stderr, "ERROR: ", logFlags)
+	Ignored     = log.New(ioutil.Discard, "ERROR: ", logFlags)
+)
+
+/*
 NewClient creates a new Telegram bot client
 */
 func NewClient(settings internal.TelegramSettings, tgapi *tgbotapi.BotAPI) *Client {
-	fmt.Println("Creating new Telegram bot client...")
+	Info.Println("Creating new Telegram bot client...")
 	return &Client{api: tgapi, Settings: settings}
 }
 
@@ -40,11 +52,11 @@ StartBot adds necessary handlers to the client and then connects,
 returning any errors that occur
 */
 func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
-	fmt.Println("Starting up Telegram bot...")
+	Info.Println("Starting up Telegram bot...")
 	var err error
 	tg.api, err = tgbotapi.NewBotAPI(tg.Settings.Token)
 	if err != nil {
-		fmt.Println("Failed to connect to Telegram")
+		Error.Println("Failed to connect to Telegram")
 		errChan <- err
 	}
 	tg.sendToIrc = sendMessage

--- a/internal/handlers/telegram/telegram_test.go
+++ b/internal/handlers/telegram/telegram_test.go
@@ -22,8 +22,11 @@ func TestNewClientBasic(t *testing.T) {
 		ShowKickMessage:     false,
 		MaxMessagePerMinute: 0,
 	}
+	logger := internal.Debug{
+		DebugLevel:  false,
+	}
 	var tgapi *tgbotapi.BotAPI
-	client := NewClient(tgRequiredSettings, tgapi)
+	client := NewClient(tgRequiredSettings, tgapi, logger)
 	assert.Equal(t, client.Settings, tgExpectedSettings, "Basic client settings should be properly set")
 }
 
@@ -46,8 +49,11 @@ func TestNewClientFull(t *testing.T) {
 		ShowKickMessage:     false,
 		MaxMessagePerMinute: 0,
 	}
+	logger := internal.Debug{
+		DebugLevel:  false,
+	}
 	var tgapi *tgbotapi.BotAPI
-	client := NewClient(tgSettings, tgapi)
+	client := NewClient(tgSettings, tgapi, logger)
 	assert.Equal(t, client.Settings, tgSettings, "All client settings should be properly set")
 	assert.NotEqual(t, client.Settings, tgDefaultSettings, "tgSettings should override defaults")
 }


### PR DESCRIPTION
Closes #245.

Good evening! I went through what we already have, and replaced the print statements generated with`fmt` by `log`. However, I noticed two issues, I would like your thoughts on.
* In the _**handlers.go**_ function, replacing the use of `fmt` in this type of statement `c.sendToTg(fmt.Sprintf(partFmt, e.Source.Name))` has not worked with `log` because the later writes to a stream, whereas the statement writes to a char array with fmt. An alternative to `fmt` would be to use `strings.Builder` but I find it more complex than the current statement.

* Adopting levels like _All, Useful_, would require the change of the flag setup from bool to int, and might require passing the debug level argument when calling `go ircClient.StartBot(ircChan, tgClient.SendMessage)` and `go tgClient.StartBot(tgChan, ircClient.SendMessage)`. To my current knowledge of golang, it would mean the use of if-else statements to determine whether to print or not.