### PR TITLE
ci: Cache Python packages for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+---
+os: linux
+dist: bionic
 jobs:
   include:
     - language: minimal
@@ -8,8 +11,9 @@ jobs:
 
     - language: python
       python: 3.7
+      cache: pip
       before_install: cd docs/
-      install: pipenv install --dev
+      install: "pip install $(pipenv lock --requirements)"
       script: sh build_docs.sh
 
 notifications:


### PR DESCRIPTION
While working on the CI improvements for Go in #262, I discovered a way
to improve the overall speed and performance of the Python job that
builds and tests our documentation. By piping the requirements to `pip`,
we can leverage the caching in Travis CI so it doesn't have to install
the docs dependencies every time a new build is made.

Not sure exactly how fast it will speed things up, but thought it was
helpful to do anyways since it wasn't that hard.