### PR TITLE
Create document handler

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -26,3 +26,20 @@ func messageHandler(tg *Client, u tgbotapi.Update) {
 
 	tg.sendToIrc(formatted)
 }
+
+/*
+documentHandler receives a document object from Telegram, and sends
+a notification to IRC.
+*/
+func documentHandler(tg *Client, u *tgbotapi.Message) {
+
+	formatted := u.From.UserName + " shared a file (" + u.Document.MimeType + ")"
+
+	if u.Caption != "" {
+		formatted += " on Telegram with caption: " + "'" + u.Caption + "'."
+	} else {
+		formatted += " on Telegram with title: " + "'" + u.Document.FileName + "'."
+	}
+
+	tg.sendToIrc(formatted)
+}

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -65,7 +65,12 @@ func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 			continue
 		}
 
-		messageHandler(tg, update)
+		if update.Message.Document != nil {
+			documentHandler(tg, update.Message)
+		} else {
+			messageHandler(tg, update)
+		}
+
 	}
 	errChan <- nil
 }


### PR DESCRIPTION
In this PR, the document handler function is added to `handler.go` in order to maintain all handlers together in the same file.

Closes #248.