### PR TITLE
fmt/log.Println like logging, Adding more verbosity 

### DIFF
--- a/internal/debug.go
+++ b/internal/debug.go
@@ -14,10 +14,10 @@ var (
 
 // DebugLogger provides an interface to call the logging functions
 type DebugLogger interface {
-	LogInfo(string)
-	LogError(error)
-	LogWarning(string)
-	PrintVersion(string)
+	LogInfo(v ...interface{})
+	LogError(v ...interface{})
+	LogWarning(v ...interface{})
+	PrintVersion(v ...interface{})
 }
 
 // Debug contains information about the debug level
@@ -25,22 +25,22 @@ type Debug struct {
 	DebugLevel  bool
 }
 
-func (d Debug) LogInfo(message string) {
+func (d Debug) LogInfo(v ...interface{}) {
 	if d.DebugLevel {
-		info.Println(message)
+		info.Println(v...)
 	}
 }
 
-func (d Debug) LogError(message error) {
-	errorLog.Println(message)
+func (d Debug) LogError(v ...interface{}) {
+	errorLog.Println(v...)
 }
 
-func (d Debug) LogWarning(message string) {
+func (d Debug) LogWarning(v ...interface{}) {
 	if d.DebugLevel {
-		warning.Println(message)
+		warning.Println(v...)
 	}
 }
 
-func (d Debug) PrintVersion(message string) {
-	info.Println(message)
+func (d Debug) PrintVersion(v ...interface{}) {
+	info.Println(v...)
 }

--- a/internal/handlers/irc/handlers.go
+++ b/internal/handlers/irc/handlers.go
@@ -25,6 +25,7 @@ so that the specified channel is joined after the server connection is establish
 */
 func connectHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
+		c.logger.LogInfo("connectHandler triggered")
 		if c.Settings.ChannelKey != "" {
 			c.Cmd.JoinKey(c.Settings.Channel, c.Settings.ChannelKey)
 		} else {
@@ -39,6 +40,7 @@ and channel messages. However, it only cares about channel messages
 */
 func messageHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
+		c.logger.LogInfo("messageHandler triggered")
 		formatted := c.Settings.Prefix + e.Source.Name + c.Settings.Suffix + " " + e.Params[1]
 		if e.IsFromChannel() {
 			c.sendToTg(formatted)
@@ -48,18 +50,21 @@ func messageHandler(c Client) func(*girc.Client, girc.Event) {
 
 func joinHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
+		c.logger.LogInfo("joinHandler triggered")
 		c.sendToTg(fmt.Sprintf(joinFmt, e.Source.Name))
 	}
 }
 
 func partHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
+		c.logger.LogInfo("partHandler triggered")
 		c.sendToTg(fmt.Sprintf(partFmt, e.Source.Name))
 	}
 }
 
 func quitHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
+		c.logger.LogInfo("quitHandler triggered")
 		c.sendToTg(fmt.Sprintf(quitFmt, e.Source.Name, e.Params[0]))
 	}
 }

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -69,8 +69,8 @@ addHandlers adds handlers for the client struct based on the settings
 that were passed in to NewClient
 */
 func (c Client) addHandlers() {
-	c.logger.LogInfo("Adding IRC event handlers...")
 	for eventType, handler := range getHandlerMapping() {
+		c.logger.LogInfo("Adding IRC event handler:", eventType)
 		c.Handlers.Add(eventType, handler(c))
 	}
 }

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -56,6 +56,7 @@ func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 		tg.logger.LogError(err)
 		errChan <- err
 	}
+	tg.logger.LogInfo("Authorized on account",tg.api.Self.UserName)
 	tg.sendToIrc = sendMessage
 
 	u := tgbotapi.NewUpdate(0)


### PR DESCRIPTION
1. Increased verbosity:
    - Whenever an irc handler triggers
    - Whenever an irc event handler has been added. Provides more details into which handlers were added.
1. Added log notification when telegram bot has logged in.