### PR TITLE
Added LogDebug

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -23,36 +23,36 @@ var (
 
 func main() {
 	flag.Parse()
-	debug := internal.Debug{DebugLevel: *flagDebug}
+	logger := internal.Debug{DebugLevel: *flagDebug}
 
 	if *flagVersion {
-		debug.PrintVersion("Current TeleIRC version:", version)
+		logger.PrintVersion("Current TeleIRC version:", version)
 		return
 	}
 
-	debug.LogInfo("Current TeleIRC version:", version)
-	// Notify that debug is enabled
-	debug.LogDebug("Debug mode enabled!")
+	logger.LogInfo("Current TeleIRC version:", version)
+	// Notify that logger is enabled
+	logger.LogDebug("Debug mode enabled!")
 
 	settings, err := internal.LoadConfig(*flagPath)
 	if err != nil {
-		debug.LogError(err)
+		logger.LogError(err)
 		os.Exit(1)
 	}
 
 	var tgapi *tgbotapi.BotAPI
-	tgClient := tg.NewClient(settings.Telegram, tgapi, debug)
+	tgClient := tg.NewClient(settings.Telegram, tgapi, logger)
 	tgChan := make(chan error)
 
-	ircClient := irc.NewClient(settings.IRC, debug)
+	ircClient := irc.NewClient(settings.IRC, logger)
 	ircChan := make(chan error)
 	go ircClient.StartBot(ircChan, tgClient.SendMessage)
 	go tgClient.StartBot(tgChan, ircClient.SendMessage)
 
 	select {
 	case ircErr := <-ircChan:
-		debug.LogError(ircErr)
+		logger.LogError(ircErr)
 	case tgErr := <-tgChan:
-		debug.LogError(tgErr)
+		logger.LogError(tgErr)
 	}
 }

--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -23,16 +23,16 @@ var (
 
 func main() {
 	flag.Parse()
-
-	debug := internal.Debug { DebugLevel:  *flagDebug }
+	debug := internal.Debug{DebugLevel: *flagDebug}
 
 	if *flagVersion {
-		debug.PrintVersion("Current TeleIRC version: " + version)
+		debug.PrintVersion("Current TeleIRC version:", version)
 		return
 	}
 
+	debug.LogInfo("Current TeleIRC version:", version)
 	// Notify that debug is enabled
-	debug.LogInfo("Debug mode enabled!")
+	debug.LogDebug("Debug mode enabled!")
 
 	settings, err := internal.LoadConfig(*flagPath)
 	if err != nil {

--- a/internal/debug.go
+++ b/internal/debug.go
@@ -6,15 +6,18 @@ import (
 )
 
 var (
-	logFlags    = log.Ldate | log.Ltime
-	info        = log.New(os.Stdout, "INFO: ", logFlags)
-	errorLog    = log.New(os.Stderr, "ERROR: ", logFlags)
-	warning     = log.New(os.Stderr, "WARNING: ", logFlags)
+	logFlags = log.Ldate | log.Ltime
+	info     = log.New(os.Stdout, "INFO: ", logFlags)
+	debug    = log.New(os.Stdout, "DEBUG: ", logFlags)
+	errorLog = log.New(os.Stderr, "ERROR: ", logFlags)
+	warning  = log.New(os.Stderr, "WARNING: ", logFlags)
+	plain    = log.New(os.Stdout, "", 0)
 )
 
 // DebugLogger provides an interface to call the logging functions
 type DebugLogger interface {
 	LogInfo(v ...interface{})
+	LogDebug(v ...interface{})
 	LogError(v ...interface{})
 	LogWarning(v ...interface{})
 	PrintVersion(v ...interface{})
@@ -22,12 +25,16 @@ type DebugLogger interface {
 
 // Debug contains information about the debug level
 type Debug struct {
-	DebugLevel  bool
+	DebugLevel bool
 }
 
 func (d Debug) LogInfo(v ...interface{}) {
+	info.Println(v...)
+}
+
+func (d Debug) LogDebug(v ...interface{}) {
 	if d.DebugLevel {
-		info.Println(v...)
+		debug.Println(v...)
 	}
 }
 
@@ -42,5 +49,5 @@ func (d Debug) LogWarning(v ...interface{}) {
 }
 
 func (d Debug) PrintVersion(v ...interface{}) {
-	info.Println(v...)
+	plain.Println(v...)
 }

--- a/internal/handlers/irc/handlers.go
+++ b/internal/handlers/irc/handlers.go
@@ -25,7 +25,7 @@ so that the specified channel is joined after the server connection is establish
 */
 func connectHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
-		c.logger.LogInfo("connectHandler triggered")
+		c.logger.LogDebug("connectHandler triggered")
 		if c.Settings.ChannelKey != "" {
 			c.Cmd.JoinKey(c.Settings.Channel, c.Settings.ChannelKey)
 		} else {
@@ -40,7 +40,7 @@ and channel messages. However, it only cares about channel messages
 */
 func messageHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
-		c.logger.LogInfo("messageHandler triggered")
+		c.logger.LogDebug("messageHandler triggered")
 		formatted := c.Settings.Prefix + e.Source.Name + c.Settings.Suffix + " " + e.Params[1]
 		if e.IsFromChannel() {
 			c.sendToTg(formatted)
@@ -50,21 +50,21 @@ func messageHandler(c Client) func(*girc.Client, girc.Event) {
 
 func joinHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
-		c.logger.LogInfo("joinHandler triggered")
+		c.logger.LogDebug("joinHandler triggered")
 		c.sendToTg(fmt.Sprintf(joinFmt, e.Source.Name))
 	}
 }
 
 func partHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
-		c.logger.LogInfo("partHandler triggered")
+		c.logger.LogDebug("partHandler triggered")
 		c.sendToTg(fmt.Sprintf(partFmt, e.Source.Name))
 	}
 }
 
 func quitHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
-		c.logger.LogInfo("quitHandler triggered")
+		c.logger.LogDebug("quitHandler triggered")
 		c.sendToTg(fmt.Sprintf(quitFmt, e.Source.Name, e.Params[0]))
 	}
 }

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -22,8 +22,8 @@ type Client struct {
 /*
 NewClient returns a new IRCClient based on the provided settings
 */
-func NewClient(settings internal.IRCSettings, debug internal.DebugLogger) Client {
-	debug.LogInfo("Creating new IRC bot client...")
+func NewClient(settings internal.IRCSettings, logger internal.DebugLogger) Client {
+	logger.LogInfo("Creating new IRC bot client...")
 	client := girc.New(girc.Config{
 		Server: settings.Server,
 		Port:   settings.Port,
@@ -36,7 +36,7 @@ func NewClient(settings internal.IRCSettings, debug internal.DebugLogger) Client
 			Pass: settings.NickServPassword,
 		}
 	}
-	return Client{client, settings, debug, nil}
+	return Client{client, settings, logger, nil}
 }
 
 /*

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -70,7 +70,7 @@ that were passed in to NewClient
 */
 func (c Client) addHandlers() {
 	for eventType, handler := range getHandlerMapping() {
-		c.logger.LogInfo("Adding IRC event handler:", eventType)
+		c.logger.LogDebug("Adding IRC event handler:", eventType)
 		c.Handlers.Add(eventType, handler(c))
 	}
 }

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -56,7 +56,7 @@ func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 		tg.logger.LogError(err)
 		errChan <- err
 	}
-	tg.logger.LogInfo("Authorized on account",tg.api.Self.UserName)
+	tg.logger.LogDebug("Authorized on account",tg.api.Self.UserName)
 	tg.sendToIrc = sendMessage
 
 	u := tgbotapi.NewUpdate(0)

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -21,9 +21,9 @@ type Client struct {
 /*
 NewClient creates a new Telegram bot client
 */
-func NewClient(settings internal.TelegramSettings, tgapi *tgbotapi.BotAPI, debug internal.DebugLogger) *Client {
-	debug.LogInfo("Creating new Telegram bot client...")
-	return &Client{api: tgapi, Settings: settings, logger: debug}
+func NewClient(settings internal.TelegramSettings, tgapi *tgbotapi.BotAPI, logger internal.DebugLogger) *Client {
+	logger.LogInfo("Creating new Telegram bot client...")
+	return &Client{api: tgapi, Settings: settings, logger: logger}
 }
 
 /*


### PR DESCRIPTION
resolves #282 
This provides basic situation awareness of the bridge. Created a new logging method called LogDebug for legitimate verbose debug messages. Bonus, I created a plain log message type without any prefix or flags for the version info.
UPDATE:
I also changed the log variable from `debug` to `logger`
## `-debug=false` or omitted
```
INFO: 2020/03/28 17:26:35 Current TeleIRC version: v2.0
INFO: 2020/03/28 17:26:35 Creating new Telegram bot client...
INFO: 2020/03/28 17:26:35 Creating new IRC bot client...
INFO: 2020/03/28 17:26:35 Starting up Telegram bot...
INFO: 2020/03/28 17:26:35 Starting up IRC bot...
```

## `-debug=true`
```
INFO: 2020/03/28 17:21:37 Current TeleIRC version: v2.0
DEBUG: 2020/03/28 17:21:37 Debug mode enabled!
INFO: 2020/03/28 17:21:37 Creating new Telegram bot client...
INFO: 2020/03/28 17:21:37 Creating new IRC bot client...
INFO: 2020/03/28 17:21:37 Starting up Telegram bot...
INFO: 2020/03/28 17:21:37 Starting up IRC bot...
DEBUG: 2020/03/28 17:21:37 Adding IRC event handler: JOIN
DEBUG: 2020/03/28 17:21:37 Adding IRC event handler: CLIENT_CONNECTED
DEBUG: 2020/03/28 17:21:37 Adding IRC event handler: PRIVMSG
DEBUG: 2020/03/28 17:21:37 Adding IRC event handler: PART
DEBUG: 2020/03/28 17:21:37 Adding IRC event handler: QUIT
DEBUG: 2020/03/28 17:21:37 Authorized on account ziky_bot
DEBUG: 2020/03/28 17:21:39 connectHandler triggered
DEBUG: 2020/03/28 17:21:43 joinHandler triggered
```