### PR TITLE
Create Telegram update handler

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -4,20 +4,33 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 )
 
-// TODO: These format strings are currently unused, so commenting out for now
-/*
-const (
-	joinFmt = "%s (@%s) has joined the Telegram Group!"
-	partFmt = "%s (@%s) has left the Telegram Group."
-)
-*/
-
 /*
 Handler specifies a function that handles a Telegram update.
 In this case, we take a Telegram client and update object,
 where the specific Handler will "handle" the given event.
 */
 type Handler = func(tg *Client, u tgbotapi.Update)
+
+/*
+updateHandler takes in a Telegram Update channel, and determines
+which handler to fire off
+*/
+func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
+	for u := range updates {
+		switch {
+		case u.Message == nil:
+			continue
+		case u.Message.Text != "":
+			messageHandler(tg, u)
+		case u.Message.Sticker != nil:
+			stickerHandler(tg, u)
+		case u.Message.Document != nil:
+			documentHandler(tg, u.Message)
+		default:
+			continue
+		}
+	}
+}
 
 /*
 messageHandler handles the Message Telegram Object, which formats the

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -2,7 +2,6 @@
 package telegram
 
 import (
-
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ritlug/teleirc/internal"
 )
@@ -56,7 +55,7 @@ func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 		tg.logger.LogError(err)
 		errChan <- err
 	}
-	tg.logger.LogDebug("Authorized on account",tg.api.Self.UserName)
+	tg.logger.LogInfo("Authorized on account", tg.api.Self.UserName)
 	tg.sendToIrc = sendMessage
 
 	u := tgbotapi.NewUpdate(0)
@@ -68,20 +67,7 @@ func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 		tg.logger.LogError(err)
 	}
 
-	// TODO: Move these lines into the updateHandler when available
-	for update := range updates {
-		switch {
-			case update.Message == nil:
-				continue
-			case update.Message.Text != "":
-				messageHandler(tg, update)
-			case update.Message.Sticker != nil:
-				stickerHandler(tg, update)
-			case update.Message.Document != nil:
-				documentHandler(tg, update.Message)
-			default:
-				continue
-		}
-	}
+	updateHandler(tg, updates)
+
 	errChan <- nil
 }


### PR DESCRIPTION
This PR piggy-backs off @kennedy's work and moves the logic for determining which handler to use for a given Telegram update into its own function in the `handler.go` file.

Any new handlers need to have a switch statement added into the `updateHandler` in order to properly route Telegram updates.

Closes #238 