### PR TITLE
Adding basic LogDebug into the updateHandler

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -19,14 +19,19 @@ func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 	for u := range updates {
 		switch {
 		case u.Message == nil:
+			tg.logger.LogDebug("Missing message data")
 			continue
 		case u.Message.Text != "":
+			tg.logger.LogDebug("messageHandler triggered")
 			messageHandler(tg, u)
 		case u.Message.Sticker != nil:
+			tg.logger.LogDebug("stickerHandler triggered")
 			stickerHandler(tg, u)
 		case u.Message.Document != nil:
+			tg.logger.LogDebug("documentHandler triggered")
 			documentHandler(tg, u.Message)
 		default:
+			tg.logger.LogDebug("triggered, but message type is currently unsupported")
 			continue
 		}
 	}

--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -19,7 +19,7 @@ func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 	for u := range updates {
 		switch {
 		case u.Message == nil:
-			tg.logger.LogDebug("Missing message data")
+			tg.logger.LogError("Missing message data")
 			continue
 		case u.Message.Text != "":
 			tg.logger.LogDebug("messageHandler triggered")
@@ -31,7 +31,7 @@ func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 			tg.logger.LogDebug("documentHandler triggered")
 			documentHandler(tg, u.Message)
 		default:
-			tg.logger.LogDebug("triggered, but message type is currently unsupported")
+			tg.logger.LogWarning("triggered, but message type is currently unsupported")
 			continue
 		}
 	}


### PR DESCRIPTION
If `--debug=true` flag is provided in startup, telegram update notifications will show as debug logs.