### PR TITLE
codeclimate: Initial commit (closes #288)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,10 @@
+---
+plugins:
+  gofmt:
+    enabled: true
+  golint:
+    enabled: true
+    config:
+      min_confidence: 0.8
+  govet:
+    enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,35 @@ jobs:
     - language: go
       go: 1.12.x
       before_install: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION"
+      before_script:
+        - curl -Lo /tmp/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+        - chmod +x /tmp/cc-test-reporter
+        - /tmp/cc-test-reporter before-build
       script: "golangci-lint run"
+      after_script:
+        - /tmp/cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
     - language: go
       go: 1.13.x
       before_install: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION"
+      before_script:
+        - curl -Lo /tmp/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+        - chmod +x /tmp/cc-test-reporter
+        - /tmp/cc-test-reporter before-build
       script: "golangci-lint run"
+      after_script:
+        - /tmp/cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
     - language: go
       go: master
       before_install: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION"
+      before_script:
+        - curl -Lo /tmp/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+        - chmod +x /tmp/cc-test-reporter
+        - /tmp/cc-test-reporter before-build
       script: "golangci-lint run"
+      after_script:
+        - /tmp/cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
     - language: python
       python: 3.7
@@ -29,6 +47,7 @@ env:
   global:
     - GO111MODULE: "on"
     - GOLANGCI_LINT_VERSION: "v1.23.8"
+    - secure: oS2J4ioikaVguUTKXsAVJ6hvw9jaMQvaERuGn32AynpqpCw55b6Sp1lwkzUc7dcQBEUIS1DJ2CbPTGmtI8q+ivDWdBQ2e2CR7N8lsFn0xbFY9TPHQ3Z+V/4aBOuhe+fdTz6tqdokhbU3EkxosA7VbKXNn+xbHTe6cZINYF/nCKqoYHw1zMUNFBjVjvF2am7KD4DHhP1o0lEXbgdjyiS/c9njknUIZxYCmLVTOatUvXucV/Oi7ZQBVH/PnX6t0nZjFh2aljjsOM1A+F0tfwwuKi+WgDEmp3Gxi3NLohAEKy//oocxuyjva8O/XxBzA/fRVimp3ibMlEZANpcvcRAS695EOOwbWYX2GEmtj3grVwXS1n0iFGd2UUsIZExP6/O74O2T8lVXzEdLSXQKGfr7XoxxzIUe9QaveukqCesUfF0vKgUwwVjNxo6mYVCKKIsAccjN1Ds0JerSp5Uz6W37HZ+KLhQzG14urcFoIWv8ofgeNNrHiMM+p5XqpfyJ1PjMXCBeCfy+OPUuneD1gHQsB+oFOs04oC+Ftc7AzyOtGCA9sLwRZSuM4NLia1FRCIEaPSSe4oMUjXUT09v+ZhGnTnvOikKW8WEmpAmfXdvk4AaZXEzGaOpYPcqQBZaedkhziUzaqvuRGpM31798LsQxZDFo0PYQwEKzbqLYr2mto0o=
 
 notifications:
   irc:


### PR DESCRIPTION
This commit adds CodeClimate back to the project, along with some
Go-specific lints and checks. This uses standard tools like `gofmt`,
`golint`, and `govet`. I'm not sure exactly what the output of these
checks will be, so this commit is an experiment to see what the results
are and how useful they are to us as a project.

https://docs.codeclimate.com/docs/gofmt
https://docs.codeclimate.com/docs/golint
https://docs.codeclimate.com/docs/govet

Closes #288.