### PR TITLE
ci: Drop Go v1.12.x CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ dist: bionic
 jobs:
   include:
     - language: go
-      go: 1.12.x
-      before_install: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION"
-      script: "golangci-lint run"
-
-    - language: go
       go: 1.13.x
       before_install: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION"
       script: "golangci-lint run"


### PR DESCRIPTION
In previous developer discussions, we mentioned the intention to support
v1.13.x versions of Go and higher. Currently our CI tests are covering
v1.12.x, v1.13.x, and latest `master` of Go. I think v1.13.x as our
"stable" version is enough, and the `master` tests give us advance
insight if something upstream breaks our code.

So, this removes v1.12.x so it is clear what our minimum supported
version of Go is.