### PR TITLE
Telegram settings checks in IRC client

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -44,7 +44,7 @@ func main() {
 	tgClient := tg.NewClient(settings.Telegram, tgapi, logger)
 	tgChan := make(chan error)
 
-	ircClient := irc.NewClient(settings.IRC, logger)
+	ircClient := irc.NewClient(&settings.IRC, &settings.Telegram, logger)
 	ircChan := make(chan error)
 	go ircClient.StartBot(ircChan, tgClient.SendMessage)
 	go tgClient.StartBot(tgChan, ircClient.SendMessage)

--- a/internal/handlers/irc/handlers.go
+++ b/internal/handlers/irc/handlers.go
@@ -68,21 +68,27 @@ func messageHandler(c Client) func(*girc.Client, girc.Event) {
 func joinHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
 		c.logger.LogDebug("joinHandler triggered")
-		c.sendToTg(fmt.Sprintf(joinFmt, e.Source.Name))
+		if c.TelegramSettings != nil && c.TelegramSettings.ShowJoinMessage {
+			c.sendToTg(fmt.Sprintf(joinFmt, e.Source.Name))
+		}
 	}
 }
 
 func partHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
 		c.logger.LogDebug("partHandler triggered")
-		c.sendToTg(fmt.Sprintf(partFmt, e.Source.Name))
+		if c.TelegramSettings != nil && c.TelegramSettings.ShowLeaveMessage {
+			c.sendToTg(fmt.Sprintf(partFmt, e.Source.Name))
+		}
 	}
 }
 
 func quitHandler(c Client) func(*girc.Client, girc.Event) {
 	return func(gc *girc.Client, e girc.Event) {
 		c.logger.LogDebug("quitHandler triggered")
-		c.sendToTg(fmt.Sprintf(quitFmt, e.Source.Name, e.Params[0]))
+		if c.TelegramSettings != nil && c.TelegramSettings.ShowLeaveMessage {
+			c.sendToTg(fmt.Sprintf(quitFmt, e.Source.Name, e.Params[0]))
+		}
 	}
 }
 

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -14,15 +14,16 @@ and the IRCSettings that were passed into NewClient
 */
 type Client struct {
 	*girc.Client
-	Settings internal.IRCSettings
-	logger   internal.DebugLogger
-	sendToTg func(string)
+	Settings         *internal.IRCSettings
+	TelegramSettings *internal.TelegramSettings
+	logger           internal.DebugLogger
+	sendToTg         func(string)
 }
 
 /*
 NewClient returns a new IRCClient based on the provided settings
 */
-func NewClient(settings internal.IRCSettings, logger internal.DebugLogger) Client {
+func NewClient(settings *internal.IRCSettings, telegramSettings *internal.TelegramSettings, logger internal.DebugLogger) Client {
 	logger.LogInfo("Creating new IRC bot client...")
 	client := girc.New(girc.Config{
 		Server: settings.Server,
@@ -36,7 +37,7 @@ func NewClient(settings internal.IRCSettings, logger internal.DebugLogger) Clien
 			Pass: settings.NickServPassword,
 		}
 	}
-	return Client{client, settings, logger, nil}
+	return Client{client, settings, telegramSettings, logger, nil}
 }
 
 /*

--- a/internal/handlers/irc/irc_test.go
+++ b/internal/handlers/irc/irc_test.go
@@ -10,15 +10,15 @@ import (
 )
 
 func TestNewClientBasic(t *testing.T) {
-	ircSettings := internal.IRCSettings{
+	ircSettings := &internal.IRCSettings{
 		Server:  "test_server",
 		Port:    1234,
 		BotName: "test_name",
 	}
 	logger := internal.Debug{
-		DebugLevel:  false,
+		DebugLevel: false,
 	}
-	client := NewClient(ircSettings, logger)
+	client := NewClient(ircSettings, nil, logger)
 
 	expectedPing, _ := time.ParseDuration("20s")
 	expectedConfig := girc.Config{
@@ -33,16 +33,16 @@ func TestNewClientBasic(t *testing.T) {
 }
 
 func TestNewClientFull(t *testing.T) {
-	ircSettings := internal.IRCSettings{
+	ircSettings := &internal.IRCSettings{
 		Server:           "test_server",
 		Port:             1234,
 		BotName:          "test_name",
 		NickServPassword: "test_pass",
 	}
 	logger := internal.Debug{
-		DebugLevel:  false,
+		DebugLevel: false,
 	}
-	client := NewClient(ircSettings, logger)
+	client := NewClient(ircSettings, nil, logger)
 	expectedPing, _ := time.ParseDuration("20s")
 	expectedConfig := girc.Config{
 		Server:    "test_server",
@@ -57,5 +57,4 @@ func TestNewClientFull(t *testing.T) {
 	}
 	assert.Equal(t, client.Settings, ircSettings, "Client settings should be properly set")
 	assert.Equal(t, client.Config, expectedConfig, "girc config should be properly set")
-
 }


### PR DESCRIPTION
I noticed that ShowJoinMessage and ShowLeaveMessage are not used anywhere, and such messages are really trashing my chat, so I added basic checks of those variables in irc events handlers. 

I tested it in my environment, but didn't have enough time to write unit tests (if necessary, I could write them later).

Also, worth mentioning: it's not obvious where the ShowKickMessage should be used. 