### PR TITLE
ci: Run go test, upload results to CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 os: linux
 dist: bionic
+
 jobs:
   include:
     - language: go
@@ -10,19 +11,27 @@ jobs:
         - curl -Lo /tmp/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
         - chmod +x /tmp/cc-test-reporter
         - /tmp/cc-test-reporter before-build
-      script: "golangci-lint run"
+      script:
+        - golangci-lint run
+        - go test -coverprofile=c.out ./...
+      # sed removes the package prefix, which is not a local path in directory
       after_script:
+        - sed -i 's/github.com\/ritlug\/teleirc\///g' c.out
         - /tmp/cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
     - language: go
-      go: master
+      go: 1.14.x
       before_install: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION"
       before_script:
         - curl -Lo /tmp/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
         - chmod +x /tmp/cc-test-reporter
         - /tmp/cc-test-reporter before-build
-      script: "golangci-lint run"
+      script:
+        - golangci-lint run
+        - go test -coverprofile=c.out ./...
+      # sed removes the package prefix, which is not a local path in directory
       after_script:
+        - sed -i 's/github.com\/ritlug\/teleirc\///g' c.out
         - /tmp/cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
     - language: python

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ TeleIRC
 [![Build Status](https://travis-ci.org/RITlug/teleirc.svg?branch=devel)](https://travis-ci.org/RITlug/teleirc)
 [![Documentation Status](https://readthedocs.org/projects/teleirc/badge/?version=latest)](http://docs.teleirc.com/en/latest/?badge=latest)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f26acd099b16fce789b3/maintainability)](https://codeclimate.com/github/RITlug/teleirc/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/f26acd099b16fce789b3/test_coverage)](https://codeclimate.com/github/RITlug/teleirc/test_coverage)
 
 Go implementation of a [Telegram](https://telegram.org/) <=> [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat) bridge for use with any IRC channel and Telegram group
 


### PR DESCRIPTION
I also changed our test suite to test on Go 1.14.x instead of latest Go
master, since I think it makes more sense to test on stable Go code than
the latest changes. Even if Go `master` tests failed, to me, it wouldn't
necessarily block a PR. Just tell us that something might be changing
soon, eventually, someday™.

Shout-out to @Zedjones for helping us figure this out in the developer
meeting today.