### PR TITLE
ci: Use exclude_patterns to avoid bad test data

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
 ---
+version: "2"
 plugins:
   gofmt:
     enabled: true
@@ -8,3 +9,11 @@ plugins:
       min_confidence: 0.8
   govet:
     enabled: true
+exclude_patterns:
+  - "**/*_test.go"
+  - "**/mock_*.go"
+  - ".github/"
+  - "assets/"
+  - "build/"
+  - "deployments/"
+  - "docs/"


### PR DESCRIPTION
@Zedjones had CodeClimate pick apart one of his pull requests because of
the interfaces used. This should get CodeClimate to calm down on the
repeated code by ignoring a few different patterns.