### PR TITLE
Add support for Telegram join/part

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	var tgapi *tgbotapi.BotAPI
-	tgClient := tg.NewClient(settings.Telegram, tgapi, logger)
+	tgClient := tg.NewClient(&settings.Telegram, &settings.IRC, tgapi, logger)
 	tgChan := make(chan error)
 
 	ircClient := irc.NewClient(&settings.IRC, &settings.Telegram, logger)

--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -57,10 +57,12 @@ func messageHandler(tg *Client, u tgbotapi.Update) {
 joinHandler handles when users join the Telegram group
 */
 func joinHandler(tg *Client, users *[]tgbotapi.User) {
-	for _, user := range *users {
-		username := GetUsername(&user)
-		formatted := username + " has joined the Telegram Group!"
-		tg.sendToIrc(formatted)
+	if tg.IRCSettings != nil && tg.IRCSettings.ShowJoinMessage {
+		for _, user := range *users {
+			username := GetUsername(&user)
+			formatted := username + " has joined the Telegram Group!"
+			tg.sendToIrc(formatted)
+		}
 	}
 }
 
@@ -68,10 +70,12 @@ func joinHandler(tg *Client, users *[]tgbotapi.User) {
 partHandler handles when users leave the Telegram group
 */
 func partHandler(tg *Client, user *tgbotapi.User) {
-	username := GetUsername(user)
-	formatted := username + " has left the Telegram Group!"
+	if tg.IRCSettings != nil && tg.IRCSettings.ShowLeaveMessage {
+		username := GetUsername(user)
+		formatted := username + " has left the Telegram Group!"
 
-	tg.sendToIrc(formatted)
+		tg.sendToIrc(formatted)
+	}
 }
 
 /*

--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -21,6 +21,10 @@ func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 		case u.Message == nil:
 			tg.logger.LogError("Missing message data")
 			continue
+		case u.Message.NewChatMembers != nil:
+			joinHandler(tg, u.Message.NewChatMembers)
+		case u.Message.LeftChatMember != nil:
+			partHandler(tg, u.Message.LeftChatMember)
 		case u.Message.Text != "":
 			tg.logger.LogDebug("messageHandler triggered")
 			messageHandler(tg, u)
@@ -31,7 +35,8 @@ func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 			tg.logger.LogDebug("documentHandler triggered")
 			documentHandler(tg, u.Message)
 		default:
-			tg.logger.LogWarning("triggered, but message type is currently unsupported")
+			tg.logger.LogWarning("Triggered, but message type is currently unsupported")
+			tg.logger.LogWarning("Unhandled Update:", u)
 			continue
 		}
 	}
@@ -44,6 +49,27 @@ Telegram update into a simple string for IRC.
 func messageHandler(tg *Client, u tgbotapi.Update) {
 	formatted := tg.Settings.Prefix + u.Message.From.UserName +
 		tg.Settings.Suffix + u.Message.Text
+
+	tg.sendToIrc(formatted)
+}
+
+/*
+joinHandler handles when users join the Telegram group
+*/
+func joinHandler(tg *Client, users *[]tgbotapi.User) {
+	for _, user := range *users {
+		username := GetUsername(&user)
+		formatted := username + " has joined the Telegram Group!"
+		tg.sendToIrc(formatted)
+	}
+}
+
+/*
+partHandler handles when users leave the Telegram group
+*/
+func partHandler(tg *Client, user *tgbotapi.User) {
+	username := GetUsername(user)
+	formatted := username + " has left the Telegram Group!"
 
 	tg.sendToIrc(formatted)
 }
@@ -63,14 +89,14 @@ func stickerHandler(tg *Client, u tgbotapi.Update) {
 documentHandler receives a document object from Telegram, and sends
 a notification to IRC.
 */
-func documentHandler(tg *Client, u *tgbotapi.Message) {
+func documentHandler(tg *Client, m *tgbotapi.Message) {
 
-	formatted := u.From.UserName + " shared a file (" + u.Document.MimeType + ")"
+	formatted := m.From.UserName + " shared a file (" + m.Document.MimeType + ")"
 
-	if u.Caption != "" {
-		formatted += " on Telegram with caption: " + "'" + u.Caption + "'."
+	if m.Caption != "" {
+		formatted += " on Telegram with caption: " + "'" + m.Caption + "'."
 	} else {
-		formatted += " on Telegram with title: " + "'" + u.Document.FileName + "'."
+		formatted += " on Telegram with title: " + "'" + m.Document.FileName + "'."
 	}
 
 	tg.sendToIrc(formatted)

--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -57,7 +57,7 @@ func messageHandler(tg *Client, u tgbotapi.Update) {
 joinHandler handles when users join the Telegram group
 */
 func joinHandler(tg *Client, users *[]tgbotapi.User) {
-	if tg.IRCSettings != nil && tg.IRCSettings.ShowJoinMessage {
+	if tg.IRCSettings.ShowJoinMessage {
 		for _, user := range *users {
 			username := GetUsername(&user)
 			formatted := username + " has joined the Telegram Group!"
@@ -70,7 +70,7 @@ func joinHandler(tg *Client, users *[]tgbotapi.User) {
 partHandler handles when users leave the Telegram group
 */
 func partHandler(tg *Client, user *tgbotapi.User) {
-	if tg.IRCSettings != nil && tg.IRCSettings.ShowLeaveMessage {
+	if tg.IRCSettings.ShowLeaveMessage {
 		username := GetUsername(user)
 		formatted := username + " has left the Telegram Group!"
 

--- a/internal/handlers/telegram/handler_test.go
+++ b/internal/handlers/telegram/handler_test.go
@@ -2,23 +2,48 @@ package telegram
 
 import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ritlug/teleirc/internal"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-func TestPartWithUsername(t *testing.T) {
+func TestPartFull_On(t *testing.T) {
 	testUser := &tgbotapi.User{
 		ID:        1,
 		FirstName: "test",
-		UserName:  "test",
+		UserName:  "testUser",
 	}
 	correct := testUser.FirstName + " (@" + testUser.UserName + ") has left the Telegram Group!"
 	clientObj := &Client{
+		IRCSettings: &internal.IRCSettings{
+			Prefix:           "<",
+			Suffix:           ">",
+			ShowLeaveMessage: true,
+		},
 		sendToIrc: func(s string) {
 			assert.Equal(t, correct, s)
 		},
 	}
+	partHandler(clientObj, testUser)
+}
 
+func TestPartFull_Off(t *testing.T) {
+	testUser := &tgbotapi.User{
+		ID:        1,
+		FirstName: "test",
+		UserName:  "testUser",
+	}
+	correct := ""
+	clientObj := &Client{
+		IRCSettings: &internal.IRCSettings{
+			Prefix:           "<",
+			Suffix:           ">",
+			ShowLeaveMessage: false,
+		},
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
 	partHandler(clientObj, testUser)
 }
 
@@ -29,10 +54,79 @@ func TestPartNoUsername(t *testing.T) {
 	}
 	correct := testUser.FirstName + " has left the Telegram Group!"
 	clientObj := &Client{
+		IRCSettings: &internal.IRCSettings{
+			Prefix:           "<",
+			Suffix:           ">",
+			ShowLeaveMessage: true,
+		},
 		sendToIrc: func(s string) {
 			assert.Equal(t, correct, s)
 		},
 	}
-
 	partHandler(clientObj, testUser)
+}
+
+func TestJoinFull_On(t *testing.T) {
+	testListUser := &[]tgbotapi.User{
+		tgbotapi.User{
+			ID:        1,
+			FirstName: "test",
+			UserName:  "testUser",
+		},
+	}
+	correct := "test (@testUser) has joined the Telegram Group!"
+	clientObj := &Client{
+		IRCSettings: &internal.IRCSettings{
+			Prefix:          "<",
+			Suffix:          ">",
+			ShowJoinMessage: true,
+		},
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
+	joinHandler(clientObj, testListUser)
+}
+
+func TestJoinFull_Off(t *testing.T) {
+	testListUser := &[]tgbotapi.User{
+		tgbotapi.User{
+			ID:        1,
+			FirstName: "test",
+			UserName:  "testUser",
+		},
+	}
+	correct := ""
+	clientObj := &Client{
+		IRCSettings: &internal.IRCSettings{
+			Prefix:          "<",
+			Suffix:          ">",
+			ShowJoinMessage: false,
+		},
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
+	joinHandler(clientObj, testListUser)
+}
+
+func TestJoinNoUsername(t *testing.T) {
+	testListUser := &[]tgbotapi.User{
+		tgbotapi.User{
+			ID:        1,
+			FirstName: "test",
+		},
+	}
+	correct := "test has joined the Telegram Group!"
+	clientObj := &Client{
+		IRCSettings: &internal.IRCSettings{
+			Prefix:          "<",
+			Suffix:          ">",
+			ShowJoinMessage: true,
+		},
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
+	joinHandler(clientObj, testListUser)
 }

--- a/internal/handlers/telegram/handler_test.go
+++ b/internal/handlers/telegram/handler_test.go
@@ -1,0 +1,38 @@
+package telegram
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPartWithUsername(t *testing.T) {
+	testUser := &tgbotapi.User{
+		ID:        1,
+		FirstName: "test",
+		UserName:  "test",
+	}
+	correct := testUser.FirstName + " (@" + testUser.UserName + ") has left the Telegram Group!"
+	clientObj := &Client{
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
+
+	partHandler(clientObj, testUser)
+}
+
+func TestPartNoUsername(t *testing.T) {
+	testUser := &tgbotapi.User{
+		ID:        1,
+		FirstName: "test",
+	}
+	correct := testUser.FirstName + " has left the Telegram Group!"
+	clientObj := &Client{
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
+
+	partHandler(clientObj, testUser)
+}

--- a/internal/handlers/telegram/helpers.go
+++ b/internal/handlers/telegram/helpers.go
@@ -1,0 +1,18 @@
+package telegram
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+/*
+GetUsername returns the username of a user. Since usernames are optional
+on Telegram, we first need to check to see if they have one set. If no
+username is set, only the first name is used.
+*/
+func GetUsername(u *tgbotapi.User) string {
+	if u.UserName == "" {
+		return u.FirstName
+	} else {
+		return u.FirstName + " (@" + u.UserName + ")"
+	}
+}

--- a/internal/handlers/telegram/helpers.go
+++ b/internal/handlers/telegram/helpers.go
@@ -5,14 +5,12 @@ import (
 )
 
 /*
-GetUsername returns the username of a user. Since usernames are optional
-on Telegram, we first need to check to see if they have one set. If no
-username is set, only the first name is used.
+GetUsername returns the name and username of a user. Since usernames are optional
+on Telegram, we first need to check to see if they have one set.
 */
 func GetUsername(u *tgbotapi.User) string {
 	if u.UserName == "" {
 		return u.FirstName
-	} else {
-		return u.FirstName + " (@" + u.UserName + ")"
 	}
+	return u.FirstName + " (@" + u.UserName + ")"
 }

--- a/internal/handlers/telegram/helpers_test.go
+++ b/internal/handlers/telegram/helpers_test.go
@@ -1,0 +1,22 @@
+package telegram
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"testing"
+)
+
+func TestGetFullUsername(t *testing.T) {
+	username := &tgbotapi.User{ID: 1, FirstName: "John", UserName: "jsmith"}
+	correct := username.FirstName + " (@" + username.UserName + ")"
+	if name := GetUsername(username); name != correct {
+		t.Errorf("Username was incorrect, got: %s, want: %s.", name, correct)
+	}
+}
+
+func TestGetUserNoUsername(t *testing.T) {
+	username := &tgbotapi.User{ID: 1, FirstName: "John"}
+	correct := username.FirstName
+	if name := GetUsername(username); name != correct {
+		t.Errorf("FirstName was incorrect, got: %s, want: %s.", name, correct)
+	}
+}

--- a/internal/handlers/telegram/helpers_test.go
+++ b/internal/handlers/telegram/helpers_test.go
@@ -2,21 +2,22 @@ package telegram
 
 import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestGetFullUsername(t *testing.T) {
 	username := &tgbotapi.User{ID: 1, FirstName: "John", UserName: "jsmith"}
 	correct := username.FirstName + " (@" + username.UserName + ")"
-	if name := GetUsername(username); name != correct {
-		t.Errorf("Username was incorrect, got: %s, want: %s.", name, correct)
-	}
+	name := GetUsername(username)
+
+	assert.Equal(t, correct, name)
 }
 
 func TestGetUserNoUsername(t *testing.T) {
 	username := &tgbotapi.User{ID: 1, FirstName: "John"}
 	correct := username.FirstName
-	if name := GetUsername(username); name != correct {
-		t.Errorf("FirstName was incorrect, got: %s, want: %s.", name, correct)
-	}
+	name := GetUsername(username)
+
+	assert.Equal(t, correct, name)
 }

--- a/internal/handlers/telegram/helpers_test.go
+++ b/internal/handlers/telegram/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestGetFullUsername(t *testing.T) {
+func TestGetUsername(t *testing.T) {
 	username := &tgbotapi.User{ID: 1, FirstName: "John", UserName: "jsmith"}
 	correct := username.FirstName + " (@" + username.UserName + ")"
 	name := GetUsername(username)
@@ -14,7 +14,7 @@ func TestGetFullUsername(t *testing.T) {
 	assert.Equal(t, correct, name)
 }
 
-func TestGetUserNoUsername(t *testing.T) {
+func TestGetNoUsername(t *testing.T) {
 	username := &tgbotapi.User{ID: 1, FirstName: "John"}
 	correct := username.FirstName
 	name := GetUsername(username)

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -11,18 +11,19 @@ Client contains information for the Telegram bridge, including
 the TelegramSettings needed to run the bot
 */
 type Client struct {
-	api       *tgbotapi.BotAPI
-	Settings  internal.TelegramSettings
-	logger    internal.DebugLogger
-	sendToIrc func(string)
+	api         *tgbotapi.BotAPI
+	Settings    *internal.TelegramSettings
+	IRCSettings *internal.IRCSettings
+	logger      internal.DebugLogger
+	sendToIrc   func(string)
 }
 
 /*
 NewClient creates a new Telegram bot client
 */
-func NewClient(settings internal.TelegramSettings, tgapi *tgbotapi.BotAPI, logger internal.DebugLogger) *Client {
+func NewClient(settings *internal.TelegramSettings, ircsettings *internal.IRCSettings, tgapi *tgbotapi.BotAPI, logger internal.DebugLogger) *Client {
 	logger.LogInfo("Creating new Telegram bot client...")
-	return &Client{api: tgapi, Settings: settings, logger: logger}
+	return &Client{api: tgapi, Settings: settings, IRCSettings: ircsettings, logger: logger}
 }
 
 /*

--- a/internal/handlers/telegram/telegram_test.go
+++ b/internal/handlers/telegram/telegram_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestNewClientBasic(t *testing.T) {
-	tgRequiredSettings := internal.TelegramSettings{
+	tgRequiredSettings := &internal.TelegramSettings{
 		Token:  "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
 		ChatID: -0000000000000,
 	}
-	tgExpectedSettings := internal.TelegramSettings{
+	tgExpectedSettings := &internal.TelegramSettings{
 		Token:               "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
 		ChatID:              -0000000000000,
 		ShowJoinMessage:     false,
@@ -23,15 +23,15 @@ func TestNewClientBasic(t *testing.T) {
 		MaxMessagePerMinute: 0,
 	}
 	logger := internal.Debug{
-		DebugLevel:  false,
+		DebugLevel: false,
 	}
 	var tgapi *tgbotapi.BotAPI
-	client := NewClient(tgRequiredSettings, tgapi, logger)
+	client := NewClient(tgRequiredSettings, nil, tgapi, logger)
 	assert.Equal(t, client.Settings, tgExpectedSettings, "Basic client settings should be properly set")
 }
 
 func TestNewClientFull(t *testing.T) {
-	tgSettings := internal.TelegramSettings{
+	tgSettings := &internal.TelegramSettings{
 		Token:               "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
 		ChatID:              -0000000000000,
 		ShowJoinMessage:     true,
@@ -40,7 +40,7 @@ func TestNewClientFull(t *testing.T) {
 		ShowKickMessage:     true,
 		MaxMessagePerMinute: 10,
 	}
-	tgDefaultSettings := internal.TelegramSettings{
+	tgDefaultSettings := &internal.TelegramSettings{
 		Token:               "000000000:AAAAAAaAAa2AaAAaoAAAA-a_aaAAaAaaaAA",
 		ChatID:              -0000000000000,
 		ShowJoinMessage:     false,
@@ -50,10 +50,10 @@ func TestNewClientFull(t *testing.T) {
 		MaxMessagePerMinute: 0,
 	}
 	logger := internal.Debug{
-		DebugLevel:  false,
+		DebugLevel: false,
 	}
 	var tgapi *tgbotapi.BotAPI
-	client := NewClient(tgSettings, tgapi, logger)
+	client := NewClient(tgSettings, nil, tgapi, logger)
 	assert.Equal(t, client.Settings, tgSettings, "All client settings should be properly set")
 	assert.NotEqual(t, client.Settings, tgDefaultSettings, "tgSettings should override defaults")
 }


### PR DESCRIPTION
## What this PR Does
* Allows support for IRC users to see when users join the Telegram channel
* If users do not wish to see this functionality, these messages can be toggled off

## What this looks like
```
Tim (@Tjzabel) has [joined|left] the Telegram Group!
```
or
```
Tim has [joined|left] the Telegram Group!
```
Closes #206 