### PR TITLE
Add Photo handler and unit tests

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -92,10 +92,12 @@ func stickerHandler(tg *Client, u tgbotapi.Update) {
 }
 
 /*
-photoHandler handles the Message.Photo Telegram object
+photoHandler handles the Message.Photo Telegram object. Only acknowledges Photo
+exists, and sends notification to IRC
 */
 func photoHandler(tg *Client, u tgbotapi.Update) {
-	formatted := u.Message.From.UserName + " shared a photo on Telegram"
+	user := u.Message.From
+	formatted := user.String() + " shared a photo on Telegram"
 
 	if u.Message.Caption != "" {
 		formatted += " with caption: " + "'" + u.Message.Caption + "'"

--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -97,11 +97,8 @@ exists, and sends notification to IRC
 */
 func photoHandler(tg *Client, u tgbotapi.Update) {
 	user := u.Message.From
-	formatted := user.String() + " shared a photo on Telegram"
-
-	if u.Message.Caption != "" {
-		formatted += " with caption: " + "'" + u.Message.Caption + "'"
-	}
+	formatted := user.String() + " shared a photo on Telegram with caption: '" +
+		u.Message.Caption + "'"
 
 	tg.sendToIrc(formatted)
 }

--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -34,6 +34,8 @@ func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 		case u.Message.Document != nil:
 			tg.logger.LogDebug("documentHandler triggered")
 			documentHandler(tg, u.Message)
+		case u.Message.Photo != nil:
+			photoHandler(tg, u)
 		default:
 			tg.logger.LogWarning("Triggered, but message type is currently unsupported")
 			tg.logger.LogWarning("Unhandled Update:", u)
@@ -85,6 +87,19 @@ Telegram message into its base Emoji unicode character.
 func stickerHandler(tg *Client, u tgbotapi.Update) {
 	formatted := tg.Settings.Prefix + u.Message.From.UserName +
 		tg.Settings.Suffix + u.Message.Sticker.Emoji
+
+	tg.sendToIrc(formatted)
+}
+
+/*
+photoHandler handles the Message.Photo Telegram object
+*/
+func photoHandler(tg *Client, u tgbotapi.Update) {
+	formatted := u.Message.From.UserName + " shared a photo on Telegram"
+
+	if u.Message.Caption != "" {
+		formatted += " with caption: " + "'" + u.Message.Caption + "'"
+	}
 
 	tg.sendToIrc(formatted)
 }

--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -35,6 +35,7 @@ func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 			tg.logger.LogDebug("documentHandler triggered")
 			documentHandler(tg, u.Message)
 		case u.Message.Photo != nil:
+			tg.logger.LogDebug("photoHandler triggered")
 			photoHandler(tg, u)
 		default:
 			tg.logger.LogWarning("Triggered, but message type is currently unsupported")

--- a/internal/handlers/telegram/handler_test.go
+++ b/internal/handlers/telegram/handler_test.go
@@ -7,7 +7,11 @@ import (
 	"testing"
 )
 
-func TestPartFull_On(t *testing.T) {
+/*
+TestPartFullOn tests the ability of the partHandler to send messages
+when ShowLeaveMessage is set to true
+*/
+func TestPartFullOn(t *testing.T) {
 	testUser := &tgbotapi.User{
 		ID:        1,
 		FirstName: "test",
@@ -27,7 +31,11 @@ func TestPartFull_On(t *testing.T) {
 	partHandler(clientObj, testUser)
 }
 
-func TestPartFull_Off(t *testing.T) {
+/*
+TestPartFullOff tests the ability of the partHandler to not send messages
+when ShowLeaveMessage is set to false
+*/
+func TestPartFullOff(t *testing.T) {
 	testUser := &tgbotapi.User{
 		ID:        1,
 		FirstName: "test",
@@ -47,6 +55,10 @@ func TestPartFull_Off(t *testing.T) {
 	partHandler(clientObj, testUser)
 }
 
+/*
+TestPartNoUsername tests the ability of the partHandler to send correctly
+formatted messages when a TG user has no username
+*/
 func TestPartNoUsername(t *testing.T) {
 	testUser := &tgbotapi.User{
 		ID:        1,
@@ -66,7 +78,11 @@ func TestPartNoUsername(t *testing.T) {
 	partHandler(clientObj, testUser)
 }
 
-func TestJoinFull_On(t *testing.T) {
+/*
+TestJoinFullOn tests the ability of the joinHandler to send messages
+when ShowJoinMessage is set to true
+*/
+func TestJoinFullOn(t *testing.T) {
 	testListUser := &[]tgbotapi.User{
 		tgbotapi.User{
 			ID:        1,
@@ -88,7 +104,11 @@ func TestJoinFull_On(t *testing.T) {
 	joinHandler(clientObj, testListUser)
 }
 
-func TestJoinFull_Off(t *testing.T) {
+/*
+TestJoinFullOff tests the ability of the joinHandler to not send messages
+when ShowJoinMessage is set to false
+*/
+func TestJoinFullOff(t *testing.T) {
 	testListUser := &[]tgbotapi.User{
 		tgbotapi.User{
 			ID:        1,
@@ -110,6 +130,10 @@ func TestJoinFull_Off(t *testing.T) {
 	joinHandler(clientObj, testListUser)
 }
 
+/*
+TestJoinNoUsername tests the ability of the joinHandler to send correctly
+formatted messages when a TG user has no username
+*/
 func TestJoinNoUsername(t *testing.T) {
 	testListUser := &[]tgbotapi.User{
 		tgbotapi.User{
@@ -310,6 +334,67 @@ func TestPhotoFull(t *testing.T) {
 				},
 			},
 			Caption: "Random Caption",
+		},
+	}
+	clientObj := &Client{
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
+	photoHandler(clientObj, updateObj)
+}
+
+/*
+TestPhotoNoUsername tests a Photo object with no username present. Should default
+to user's FirstName
+*/
+func TestPhotoNoUsername(t *testing.T) {
+	correct := "test shared a photo on Telegram with caption: 'Random Caption'"
+	updateObj := tgbotapi.Update{
+		Message: &tgbotapi.Message{
+			From: &tgbotapi.User{
+				FirstName: "test",
+			},
+			Photo: &[]tgbotapi.PhotoSize{
+				tgbotapi.PhotoSize{
+					FileID:   "https://teleirc.com/file.png",
+					Width:    1,
+					Height:   1,
+					FileSize: 1,
+				},
+			},
+			Caption: "Random Caption",
+		},
+	}
+	clientObj := &Client{
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
+	photoHandler(clientObj, updateObj)
+}
+
+/*
+TestPhotoNoCaption tests messages are correctly formatted when a photo
+is uploaded without a caption
+*/
+func TestPhotoNoCaption(t *testing.T) {
+	correct := "user shared a photo on Telegram with caption: ''"
+	updateObj := tgbotapi.Update{
+		Message: &tgbotapi.Message{
+			From: &tgbotapi.User{
+				FirstName: "test",
+				UserName:  "user",
+			},
+			Photo: &[]tgbotapi.PhotoSize{
+				tgbotapi.PhotoSize{
+					FileID:   "https://teleirc.com/file.png",
+					Width:    1,
+					Height:   1,
+					FileSize: 1,
+				},
+			},
+			Caption: "",
 		},
 	}
 	clientObj := &Client{

--- a/internal/handlers/telegram/handler_test.go
+++ b/internal/handlers/telegram/handler_test.go
@@ -289,3 +289,33 @@ func TestDocumentFull(t *testing.T) {
 	}
 	documentHandler(clientObj, updateObj.Message)
 }
+
+/*
+TestPhotoFull tests a complete Photo object
+*/
+func TestPhotoFull(t *testing.T) {
+	correct := "user shared a photo on Telegram with caption: 'Random Caption'"
+	updateObj := tgbotapi.Update{
+		Message: &tgbotapi.Message{
+			From: &tgbotapi.User{
+				FirstName: "test",
+				UserName:  "user",
+			},
+			Photo: &[]tgbotapi.PhotoSize{
+				tgbotapi.PhotoSize{
+					FileID:   "https://teleirc.com/file.png",
+					Width:    1,
+					Height:   1,
+					FileSize: 1,
+				},
+			},
+			Caption: "Random Caption",
+		},
+	}
+	clientObj := &Client{
+		sendToIrc: func(s string) {
+			assert.Equal(t, correct, s)
+		},
+	}
+	photoHandler(clientObj, updateObj)
+}


### PR DESCRIPTION
## What this PR Does
* Allows support for IRC users to see when Telegram users send photos

## What this looks like
```
Tjzabel shared a photo on Telegram with caption: 'My cool caption'
```
or
```
Tjzabel shared a photo on Telegram with caption: ''
```
Closes #195 