### PR TITLE
codeclimate: Add exclusion patterns for more files

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,8 +10,17 @@ plugins:
   govet:
     enabled: true
 exclude_patterns:
+  # glob patterns
+  - "**/.dockerignore"
+  - "**/.gitignore"
+  - "**/go.mod"
+  - "**/go.sum"
   - "**/*_test.go"
   - "**/mock_*.go"
+  - "**/*.md"
+  - "**/*.txt"
+  - "**/*.yml"
+  # project-specific folders
   - ".github/"
   - "assets/"
   - "build/"


### PR DESCRIPTION
This commit hides more files from CodeClimate that we don't want it to
measure. I know these files show up in the code progress reports, but it
is not clear to me if they are also included as untested source code for
our overall test coverage.