### PR TITLE
Write unit tests for message handler

### DIFF
--- a/internal/handlers/irc/handlers.go
+++ b/internal/handlers/irc/handlers.go
@@ -58,8 +58,8 @@ func messageHandler(c ClientInterface) func(*girc.Client, girc.Event) {
 		c.Logger().LogDebug("messageHandler triggered")
 		// Only send if user is not in blacklist
 		if !(checkBlacklist(c, e.Source.Name)) {
-			formatted := c.IRCSettings().Prefix + e.Source.Name + c.IRCSettings().Suffix + " " + e.Params[1]
 			if e.IsFromChannel() {
+				formatted := c.IRCSettings().Prefix + e.Source.Name + c.IRCSettings().Suffix + " " + e.Params[1]
 				c.SendToTg(formatted)
 			}
 		}

--- a/internal/handlers/irc/handlers_test.go
+++ b/internal/handlers/irc/handlers_test.go
@@ -314,3 +314,120 @@ func TestKickHandlerNoReason(t *testing.T) {
 		},
 	})
 }
+
+func TestMessageHandlerInBlacklist(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	defer ctrl.Finish()
+
+	ircSettings := internal.IRCSettings{
+		IRCBlacklist: []string{
+			"SomeUser",
+		},
+	}
+
+	mockClient := NewMockClientInterface(ctrl)
+	mockLogger := internal.NewMockDebugLogger(ctrl)
+	mockClient.
+		EXPECT().
+		Logger().
+		Return(mockLogger)
+	mockLogger.
+		EXPECT().
+		LogDebug(gomock.Eq("messageHandler triggered"))
+	mockClient.
+		EXPECT().
+		IRCSettings().
+		Return(&ircSettings)
+	mockClient.
+		EXPECT().
+		SendToTg(gomock.Any()).
+		MaxTimes(0)
+
+	myHandler := messageHandler(mockClient)
+	myHandler(&girc.Client{}, girc.Event{
+		Source: &girc.Source{
+			Name: "SomeUser",
+		},
+	})
+}
+
+func TestMessageHandlerNotChannel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	defer ctrl.Finish()
+
+	ircSettings := internal.IRCSettings{
+		IRCBlacklist: []string{},
+	}
+
+	mockClient := NewMockClientInterface(ctrl)
+	mockLogger := internal.NewMockDebugLogger(ctrl)
+	mockClient.
+		EXPECT().
+		Logger().
+		Return(mockLogger)
+	mockLogger.
+		EXPECT().
+		LogDebug(gomock.Eq("messageHandler triggered"))
+	mockClient.
+		EXPECT().
+		IRCSettings().
+		Return(&ircSettings)
+	mockClient.
+		EXPECT().
+		SendToTg(gomock.Any()).
+		MaxTimes(0)
+
+	myHandler := messageHandler(mockClient)
+	myHandler(&girc.Client{}, girc.Event{
+		Source: &girc.Source{
+			Name: "SomeUser",
+		},
+		// Need to not be PRIVMSG or NOTICE
+		Command: girc.KICK,
+	})
+}
+
+func TestMessageHandlerFull(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	defer ctrl.Finish()
+
+	ircSettings := internal.IRCSettings{
+		IRCBlacklist: []string{},
+		Prefix:       "<<",
+		Suffix:       ">>",
+	}
+
+	mockClient := NewMockClientInterface(ctrl)
+	mockLogger := internal.NewMockDebugLogger(ctrl)
+	mockClient.
+		EXPECT().
+		Logger().
+		Return(mockLogger)
+	mockLogger.
+		EXPECT().
+		LogDebug(gomock.Eq("messageHandler triggered"))
+	mockClient.
+		EXPECT().
+		IRCSettings().
+		Return(&ircSettings).
+		AnyTimes()
+	mockClient.
+		EXPECT().
+		SendToTg(gomock.Eq("<<SomeUser>> a message"))
+
+	myHandler := messageHandler(mockClient)
+	myHandler(&girc.Client{}, girc.Event{
+		Source: &girc.Source{
+			Name: "SomeUser",
+		},
+		// Need to be PRIVMSG
+		Command: girc.PRIVMSG,
+		Params: []string{
+			"#testchannel",
+			"a message",
+		},
+	})
+}

--- a/internal/handlers/irc/handlers_test.go
+++ b/internal/handlers/irc/handlers_test.go
@@ -315,6 +315,69 @@ func TestKickHandlerNoReason(t *testing.T) {
 	})
 }
 
+func TestConnectHandlerKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	defer ctrl.Finish()
+
+	ircSettings := internal.IRCSettings{
+		Channel:    "SomeChannel",
+		ChannelKey: "SomeKey",
+	}
+
+	mockClient := NewMockClientInterface(ctrl)
+	mockLogger := internal.NewMockDebugLogger(ctrl)
+	mockClient.
+		EXPECT().
+		Logger().
+		Return(mockLogger)
+	mockLogger.
+		EXPECT().
+		LogDebug(gomock.Eq("connectHandler triggered"))
+	mockClient.
+		EXPECT().
+		IRCSettings().
+		Return(&ircSettings).
+		AnyTimes()
+	mockClient.
+		EXPECT().
+		JoinKey(gomock.Eq("SomeChannel"), gomock.Eq("SomeKey"))
+
+	myHandler := connectHandler(mockClient)
+	myHandler(&girc.Client{}, girc.Event{})
+}
+
+func TestConnectHandlerNoKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	defer ctrl.Finish()
+
+	ircSettings := internal.IRCSettings{
+		Channel: "SomeChannel",
+	}
+
+	mockClient := NewMockClientInterface(ctrl)
+	mockLogger := internal.NewMockDebugLogger(ctrl)
+	mockClient.
+		EXPECT().
+		Logger().
+		Return(mockLogger)
+	mockLogger.
+		EXPECT().
+		LogDebug(gomock.Eq("connectHandler triggered"))
+	mockClient.
+		EXPECT().
+		IRCSettings().
+		Return(&ircSettings).
+		AnyTimes()
+	mockClient.
+		EXPECT().
+		Join(gomock.Eq("SomeChannel"))
+
+	myHandler := connectHandler(mockClient)
+	myHandler(&girc.Client{}, girc.Event{})
+}
+
 func TestMessageHandlerInBlacklist(t *testing.T) {
 	ctrl := gomock.NewController(t)
 


### PR DESCRIPTION
Added unit tests for the message handler and moved a string concatenation to the inside of a check since it was unused if the check failed.

Resolves #269