### PR TITLE
Developer Docs: code conventions

### DIFF
--- a/docs/dev/code-conventions.md
+++ b/docs/dev/code-conventions.md
@@ -1,0 +1,28 @@
+TeleIRC Code Conventions
+========================
+
+This page explains TeleIRC coding best practices.
+This was originally written by Tim Zabel ([@Tjzabel](https://github.com/Tjzabel)).
+
+
+## Naming Conventions
+
+TeleIRC constitutes two halves: IRC and Telegram.
+Function names should be agnostic to each platform. 
+Lastly, function names should be consistent across IRC and Telegram where possible.
+
+```go
+func (*tg Client) SendMessage(msg string) {
+    ...
+}
+```
+
+
+## Handlers
+
+Handlers are blocks of code responsible for "handling" specific message types.
+Such handlers should be named appropriately in camelCase.
+
+```go
+func joinHandler(...)
+```


### PR DESCRIPTION
This PR adds common coding conventions specific to TeleIRC.

![image](https://user-images.githubusercontent.com/22552344/81484848-ff658300-9216-11ea-9aff-725fedd58687.png)


Closes #73 