### PR TITLE
No need for space in defaults, already in handler

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -41,7 +41,7 @@ type TelegramSettings struct {
 	Token               string `env:"TELEIRC_TOKEN,required"`
 	ChatID              int64  `env:"TELEGRAM_CHAT_ID,required"`
 	Prefix              string `env:"TELEGRAM_MESSAGE_PREFIX" envDefault:"<"`
-	Suffix              string `env:"TELEGRAM_MESSAGE_SUFFIX" envDefault:"> "`
+	Suffix              string `env:"TELEGRAM_MESSAGE_SUFFIX" envDefault:">"`
 	ShowJoinMessage     bool   `env:"SHOW_JOIN_MESSAGE" envDefault:"false"`
 	ShowActionMessage   bool   `env:"SHOW_ACTION_MESSAGE" envDefault:"false"`
 	ShowLeaveMessage    bool   `env:"SHOW_LEAVE_MESSAGE" envDefault:"false"`


### PR DESCRIPTION
It's been a while, so may as well throw my hat in the ring again in the spirit of Hacktoberfest :)

Fixes #333. The handler already appends a space after the suffix, so there isn't a need for a space in the default suffix.

_Alternatively_ we could change the formatting in the handler and leave the space here, not sure if we have a preference.