### PR TITLE
Update version field

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "v2.0"
+	version = "v2.0.1"
 )
 
 var (


### PR DESCRIPTION
Now that we are on `v.2.0.1` we need to make sure our versioning reflects that. 

After this quick PR, I am going to create an issue to see if there is a better way we can track the current TeleIRC version.