### PR TITLE
When CTRL+C (SIGTERM) is specified, TeleIRC now exits gracefully

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -42,7 +42,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	signalChannel := make(chan os.Signal)
+	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
 
 	var tgapi *tgbotapi.BotAPI

--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -4,6 +4,8 @@ package main
 import (
 	"flag"
 	"os"
+	"os/signal"
+	"syscall"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ritlug/teleirc/internal"
@@ -40,12 +42,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	signalChannel := make(chan os.Signal)
+	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
+
 	var tgapi *tgbotapi.BotAPI
 	tgClient := tg.NewClient(&settings.Telegram, &settings.IRC, tgapi, logger)
 	tgChan := make(chan error)
 
 	ircClient := irc.NewClient(&settings.IRC, &settings.Telegram, logger)
 	ircChan := make(chan error)
+
 	go ircClient.StartBot(ircChan, tgClient.SendMessage)
 	go tgClient.StartBot(tgChan, ircClient.SendMessage)
 
@@ -54,5 +60,12 @@ func main() {
 		logger.LogError(ircErr)
 	case tgErr := <-tgChan:
 		logger.LogError(tgErr)
+	case signal := <-signalChannel:
+		logger.LogInfo("SIGNAL RECEIVED: " + signal.String())
+		break
 	}
+
+	logger.LogInfo("Shutting Down...")
+	ircClient.Close()
+	logger.LogInfo("Exiting")
 }

--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -61,7 +61,7 @@ func main() {
 	case tgErr := <-tgChan:
 		logger.LogError(tgErr)
 	case signal := <-signalChannel:
-		logger.LogInfo("SIGNAL RECEIVED: " + signal.String())
+		logger.LogInfo("Signal Received: " + signal.String())
 		break
 	}
 

--- a/docs/user/config-file-glossary.rst
+++ b/docs/user/config-file-glossary.rst
@@ -72,6 +72,10 @@ IRC settings
 ``IRC_NO_FORWARD_PREFIX="[off]"``
     A string users can prefix their message with to prevent it from being relayed across the bridge. Removing this option or setting it to "" disables it.
 
+``IRC_QUIT_MESSAGE``
+    A string that TeleIRC sends to the IRC channel when the application exits using IRC's "QUIT" command.
+    If not specified, it simply closes the connection without providing a reason.
+    The bot must be connected to a server for a certain amount of time for the server to send the quit message to the channel.
 
 *****************
 Telegram settings

--- a/env.example
+++ b/env.example
@@ -27,6 +27,7 @@ IRC_EDITED_PREFIX="[EDIT] "
 IRC_MAX_MESSAGE_LENGTH=400
 IRC_SHOW_ZWSP=true
 IRC_NO_FORWARD_PREFIX=""
+IRC_QUIT_MESSAGE="Shutting Down"
 
 
 ###############################################################################

--- a/internal/config.go
+++ b/internal/config.go
@@ -36,6 +36,7 @@ type IRCSettings struct {
 	IRCBlacklist        []string `env:"IRC_BLACKLIST" envDefault:"[]string{}"`
 	UseSSL              bool     `env:"IRC_USE_SSL" envDefault:"false"`
 	NoForwardPrefix     string   `env:"IRC_NO_FORWARD_PREFIX" envDefault:""`
+	QuitMessage         string   `env:"IRC_QUIT_MESSAGE" envDefault:""`
 }
 
 // TelegramSettings includes settings related to the Telegram bot/message relaying

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -143,7 +143,7 @@ func (c Client) addHandlers() {
 }
 
 /*
-Disconnects from the IRC channel.  If a quit message
+Close disconnects from the IRC channel.  If a quit message
 was specified, it gets sent first.
 Some servers may not report the QUIT message unless the bot
 was in the channel for a minimum amount of time.

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -141,3 +141,17 @@ func (c Client) addHandlers() {
 		c.AddHandler(eventType, handler(c))
 	}
 }
+
+/*
+Disconnects from the IRC channel.  If a quit message
+was specified, it gets sent first.
+Some servers may not report the QUIT message unless the bot
+was in the channel for a minimum amount of time.
+*/
+func (c Client) Close() {
+	if c.IRCSettings().QuitMessage != "" {
+		c.Client.Quit(c.IRCSettings().QuitMessage)
+	} else {
+		c.Client.Close()
+	}
+}


### PR DESCRIPTION
I noticed when hitting CTRL+C when TeleIRC was running, the bot didn't exit gracefully, it exited with EXITCODE 2.

This pull captures the SIGTERM signal when CTRL+C is hit (or when something sends SIGTERM to the process), and then has the program gracefully exit.  First, however, it will send the IRC QUIT message if it is specified in the config.

...

I didn't add unit tests to irc.go for the new function, I'm not experienced in go to figure out how to mock a third-party library.  But the function is simple enough where I'm not super concerned.