### PR TITLE
irc: Add support for multiple IP addresses (closes #324)

### DIFF
--- a/docs/user/config-file-glossary.rst
+++ b/docs/user/config-file-glossary.rst
@@ -11,7 +11,12 @@ This glossary is intended for advanced users.
 IRC settings
 ************
 
+Host connection settings
+========================
 
+``IRC_HOST_IP=""``
+    Specify IP address to use for IRC connection.
+    Useful for hosts with multiple IP addresses.
 
 Server connection settings
 ==============================

--- a/env.example
+++ b/env.example
@@ -8,6 +8,9 @@
 #                                                                             #
 ###############################################################################
 
+#####----- Host connection settings -----#####
+IRC_HOST_IP=""
+
 
 #####----- IRC server connection settings -----#####
 IRC_SERVER=chat.freenode.net

--- a/internal/config.go
+++ b/internal/config.go
@@ -15,6 +15,7 @@ const defaultPath = ".env"
 
 // IRCSettings includes settings related to the IRC bot/message relaying
 type IRCSettings struct {
+	BindAddress         string   `env:"IRC_HOST_IP" envDefault:""`
 	Server              string   `env:"IRC_SERVER,required"`
 	ServerPass          string   `env:"IRC_SERVER_PASSWORD" envDefault:""`
 	Port                int      `env:"IRC_PORT" envDefault:"6667" validate:"min=0,max=65535"`

--- a/internal/handlers/irc/irc.go
+++ b/internal/handlers/irc/irc.go
@@ -34,6 +34,11 @@ func NewClient(settings *internal.IRCSettings, telegramSettings *internal.Telegr
 		SSL:    settings.UseSSL,
 	})
 
+	// Bind an IP address for IRC connection
+	if settings.BindAddress != "" {
+		client.Config.Bind = settings.BindAddress
+	}
+
 	// IRC server authentication
 	if settings.ServerPass != "" {
 		client.Config.ServerPass = settings.ServerPass

--- a/internal/handlers/irc/irc_test.go
+++ b/internal/handlers/irc/irc_test.go
@@ -37,6 +37,7 @@ func TestNewClientBasic(t *testing.T) {
 
 func TestNewClientFull(t *testing.T) {
 	ircSettings := &internal.IRCSettings{
+		BindAddress:      "129.21.13.37",
 		Server:			  "irc.batcave.intl",
 		ServerPass:		  "BatmanNeverDies!",
 		Port:			  1337,
@@ -52,6 +53,7 @@ func TestNewClientFull(t *testing.T) {
 	client := NewClient(ircSettings, nil, logger)
 	expectedPing, _ := time.ParseDuration("20s")
 	expectedConfig := girc.Config{
+		Bind:           "129.21.13.37",
 		Server:			"irc.batcave.intl",
 		ServerPass:		"BatmanNeverDies!",
 		Port:			1337,

--- a/internal/handlers/irc/irc_test.go
+++ b/internal/handlers/irc/irc_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewClientBasic(t *testing.T) {
 	ircSettings := &internal.IRCSettings{
 		Server:   "irc.batcave.intl",
-		Port:	  1337,
+		Port:     1337,
 		BotIdent: "alfred",
 		BotName:  "Alfred Pennyworth",
 		BotNick:  "alfred-p",
@@ -22,13 +22,13 @@ func TestNewClientBasic(t *testing.T) {
 	}
 	client := NewClient(ircSettings, nil, logger)
 
-	expectedPing, _:= time.ParseDuration("20s")
+	expectedPing, _ := time.ParseDuration("20s")
 	expectedConfig := girc.Config{
 		Server:    "irc.batcave.intl",
-		Port:	   1337,
-		Nick:	   "alfred-p",
-		Name:	   "Alfred Pennyworth",
-		User:	   "alfred",
+		Port:      1337,
+		Nick:      "alfred-p",
+		Name:      "Alfred Pennyworth",
+		User:      "alfred",
 		PingDelay: expectedPing,
 	}
 	assert.Equal(t, client.Settings, ircSettings, "Client settings should be properly set")
@@ -38,13 +38,13 @@ func TestNewClientBasic(t *testing.T) {
 func TestNewClientFull(t *testing.T) {
 	ircSettings := &internal.IRCSettings{
 		BindAddress:      "129.21.13.37",
-		Server:			  "irc.batcave.intl",
-		ServerPass:		  "BatmanNeverDies!",
-		Port:			  1337,
-		BotIdent:		  "alfred",
-		BotName:		  "Alfred Pennyworth",
-		BotNick:		  "alfred-p",
-		NickServUser:	  "irc_moderators",
+		Server:           "irc.batcave.intl",
+		ServerPass:       "BatmanNeverDies!",
+		Port:             1337,
+		BotIdent:         "alfred",
+		BotName:          "Alfred Pennyworth",
+		BotNick:          "alfred-p",
+		NickServUser:     "irc_moderators",
 		NickServPassword: "ProtectGotham",
 	}
 	logger := internal.Debug{
@@ -53,15 +53,15 @@ func TestNewClientFull(t *testing.T) {
 	client := NewClient(ircSettings, nil, logger)
 	expectedPing, _ := time.ParseDuration("20s")
 	expectedConfig := girc.Config{
-		Bind:           "129.21.13.37",
-		Server:			"irc.batcave.intl",
-		ServerPass:		"BatmanNeverDies!",
-		Port:			1337,
-		Nick:			"alfred-p",
-		Name:			"Alfred Pennyworth",
-		User:			"alfred",
-		PingDelay:		expectedPing,
-		SASL:			&girc.SASLPlain{
+		Bind:       "129.21.13.37",
+		Server:     "irc.batcave.intl",
+		ServerPass: "BatmanNeverDies!",
+		Port:       1337,
+		Nick:       "alfred-p",
+		Name:       "Alfred Pennyworth",
+		User:       "alfred",
+		PingDelay:  expectedPing,
+		SASL: &girc.SASLPlain{
 			User: "irc_moderators",
 			Pass: "ProtectGotham",
 		},


### PR DESCRIPTION
This commit adds support for the `Bind` config option in girc. This way,
a user can configure a custom IP address for the IRC connection. This is
useful for hosts with multiple assigned IP addresses.

Closes #324.

---

In theory, this should just work. But since I do not have a host environment with multiple IP addresses, it was not quick or easy for me to test this. I'd be curious for someone with multiple IP addresses to actually run this change.