### PR TITLE
docs: Add mIRC Italia Crew to "Who uses TeleIRC?" (closes #357)

### DIFF
--- a/docs/about/who-uses-teleirc.rst
+++ b/docs/about/who-uses-teleirc.rst
@@ -8,8 +8,8 @@ v2.x.x
 
 The following projects and communities use RITlug TeleIRC v2.0.0 or later:
 
-- None yet.
-  Check back later!
+- mIRC Italia Crew (`@mircitaliacrew <https://t.me/mircitaliacrew>`_ | `#mircitaliacrew <https://webchat.freenode.net/#mircitaliacrew>`_)
+
 
 ******
 v1.x.x


### PR DESCRIPTION
This commit adds the mIRC Italia Crew to the "Who uses TeleIRC" page,
per the request made by @deltagnan in #357.

Closes #357.