### PR TITLE
fix: Fix broken link to "Config file glossary" in env.example file.

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 # vim:set filetype=sh:
 # See the Config File Glossary for instructions.
-# https://docs.teleirc.com/en/latest/config-file-glossary/
+# https://docs.teleirc.com/en/latest/user/config-file-glossary/
 
 ###############################################################################
 #                                                                             #


### PR DESCRIPTION
1. Why is this change neccesary?
The current link to the "Config file glossary" documentation is broken.

Screenshot to showcase the issue:
![Screenshot that shows a message saying "Sorry, this page does not exist yet".](https://user-images.githubusercontent.com/10160626/110066060-3e307080-7d36-11eb-906f-31fd0e35bbff.png)

2. How does it address the issue?
By adding the right URL in the env.example file.

3. What side effects does this change have?
None.
