### PR TITLE
only forward messages we care about

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -61,6 +61,12 @@ func messageHandler(tg *Client, u tgbotapi.Update) {
 		return
 	}
 
+	// Don't forward messages to IRC that didn't come from the
+	// chat we're bridging
+	if u.Message.Chat.ID != tg.Settings.ChatID {
+		return
+	}
+
 	formatted := fmt.Sprintf("%s%s%s %s",
 		tg.Settings.Prefix,
 		username,

--- a/internal/handlers/telegram/handler_test.go
+++ b/internal/handlers/telegram/handler_test.go
@@ -742,3 +742,39 @@ func TestMessageZwsp(t *testing.T) {
 
 	messageHandler(clientObj, updateObj)
 }
+
+func TestMessageFromWrongTelegramChat(t *testing.T) {
+	testUser := &tgbotapi.User{
+		ID:        1,
+		UserName:  "test",
+		FirstName: "testing",
+		LastName:  "123",
+	}
+	testChat := &tgbotapi.Chat{
+		ID: 100,
+	}
+	correct := fmt.Sprintf("<%s> Random Text", "t"+"​"+"est")
+
+	updateObj := tgbotapi.Update{
+		Message: &tgbotapi.Message{
+			From: testUser,
+			Text: "Random Text",
+			Chat: testChat,
+		},
+	}
+	clientObj := &Client{
+		Settings: &internal.TelegramSettings{
+			Prefix: "<",
+			Suffix: ">",
+			ChatID: 101,
+		},
+		IRCSettings: &internal.IRCSettings{
+			ShowZWSP: true,
+		},
+		sendToIrc: func(s string) {
+			assert.False(t, true, "sendToIrc should not be called if the telegram chat ID has a mismatch")
+		},
+	}
+
+	messageHandler(clientObj, updateObj)
+}

--- a/internal/handlers/telegram/handler_test.go
+++ b/internal/handlers/telegram/handler_test.go
@@ -641,18 +641,24 @@ func TestMessageRandomWithoutUsername(t *testing.T) {
 		FirstName: "testing",
 		LastName:  "123",
 	}
+	testChat := &tgbotapi.Chat{
+		ID: 100,
+	}
+
 	correct := fmt.Sprintf("<%s> Random Text", testUser.FirstName)
 
 	updateObj := tgbotapi.Update{
 		Message: &tgbotapi.Message{
 			From: testUser,
 			Text: "Random Text",
+			Chat: testChat,
 		},
 	}
 	clientObj := &Client{
 		Settings: &internal.TelegramSettings{
 			Prefix: "<",
 			Suffix: ">",
+			ChatID: 100,
 		},
 		IRCSettings: &internal.IRCSettings{
 			ShowZWSP: false,
@@ -672,17 +678,22 @@ func TestMessageRandomWithNoForward(t *testing.T) {
 		FirstName: "testing",
 		LastName:  "123",
 	}
+	testChat := &tgbotapi.Chat{
+		ID: 100,
+	}
 
 	updateObj := tgbotapi.Update{
 		Message: &tgbotapi.Message{
 			From: testUser,
 			Text: "[off] Random Text",
+			Chat: testChat,
 		},
 	}
 	clientObj := &Client{
 		Settings: &internal.TelegramSettings{
 			Prefix: "<",
 			Suffix: ">",
+			ChatID: 100,
 		},
 		IRCSettings: &internal.IRCSettings{
 			ShowZWSP: false,
@@ -703,18 +714,23 @@ func TestMessageZwsp(t *testing.T) {
 		FirstName: "testing",
 		LastName:  "123",
 	}
+	testChat := &tgbotapi.Chat{
+		ID: 100,
+	}
 	correct := fmt.Sprintf("<%s> Random Text", "t"+"​"+"est")
 
 	updateObj := tgbotapi.Update{
 		Message: &tgbotapi.Message{
 			From: testUser,
 			Text: "Random Text",
+			Chat: testChat,
 		},
 	}
 	clientObj := &Client{
 		Settings: &internal.TelegramSettings{
 			Prefix: "<",
 			Suffix: ">",
+			ChatID: 100,
 		},
 		IRCSettings: &internal.IRCSettings{
 			ShowZWSP: true,

--- a/internal/handlers/telegram/handler_test.go
+++ b/internal/handlers/telegram/handler_test.go
@@ -604,12 +604,16 @@ func TestMessageRandomWithUsername(t *testing.T) {
 		FirstName: "testing",
 		LastName:  "123",
 	}
+	testChat := &tgbotapi.Chat {
+		ID: 100,
+	}
 	correct := fmt.Sprintf("<%s> Random Text", testUser.String())
 
 	updateObj := tgbotapi.Update{
 		Message: &tgbotapi.Message{
 			From: testUser,
 			Text: "Random Text",
+			Chat: testChat,
 		},
 	}
 
@@ -617,6 +621,7 @@ func TestMessageRandomWithUsername(t *testing.T) {
 		Settings: &internal.TelegramSettings{
 			Prefix: "<",
 			Suffix: ">",
+			ChatID: 100,
 		},
 		IRCSettings: &internal.IRCSettings{
 			ShowZWSP: false,

--- a/internal/handlers/telegram/handler_test.go
+++ b/internal/handlers/telegram/handler_test.go
@@ -753,7 +753,6 @@ func TestMessageFromWrongTelegramChat(t *testing.T) {
 	testChat := &tgbotapi.Chat{
 		ID: 100,
 	}
-	correct := fmt.Sprintf("<%s> Random Text", "t"+"​"+"est")
 
 	updateObj := tgbotapi.Update{
 		Message: &tgbotapi.Message{


### PR DESCRIPTION
Should fix #366.

Looks like we just were blindly forwarding messages to IRC without checking where they came from. The opposite direction (IRC to Telegram) appears not to have this problem.