### PR TITLE
Add the username when a TG user reply to someone

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -56,6 +56,7 @@ Telegram update into a simple string for IRC.
 */
 func messageHandler(tg *Client, u tgbotapi.Update) {
 	username := GetUsername(tg.IRCSettings.ShowZWSP, u.Message.From)
+	replyUsername := ""
 
 	if tg.IRCSettings.NoForwardPrefix != "" && strings.HasPrefix(u.Message.Text, tg.IRCSettings.NoForwardPrefix) {
 		return
@@ -67,10 +68,14 @@ func messageHandler(tg *Client, u tgbotapi.Update) {
 		return
 	}
 
-	formatted := fmt.Sprintf("%s%s%s %s",
+	if u.Message.ReplyToMessage != nil {
+		replyUsername = GetUsername(tg.IRCSettings.ShowZWSP, u.Message.ReplyToMessage.From) + ":"
+	}
+	formatted := fmt.Sprintf("%s%s%s%s %s",
 		tg.Settings.Prefix,
 		username,
 		tg.Settings.Suffix,
+		replyUsername,
 		// Trim unexpected trailing whitespace
 		strings.Trim(u.Message.Text, " "))
 	tg.sendToIrc(formatted)


### PR DESCRIPTION
This pull request try to convey the fact that someone replied to someone else when discussing, by adapting the message to the IRC convention.

If user A reply to user B on TG, this will appear like:
```
tg-bot>  <A> B: A very valid point, but I still think chocolate and soy sauce are incompatible
```

Instead of:

```
tg-bot>  <A> A very valid point, but I still think chocolate and soy sauce are incompatible
```

This is quite useful since people sometime answer a few hours later and it is hard to follow from irc.

I didn't test the patch (yet), but it compile. 