### PR TITLE
:beetle: tests: Add initial value to var declaration

### DIFF
--- a/internal/handlers/irc/handlers_test.go
+++ b/internal/handlers/irc/handlers_test.go
@@ -114,8 +114,7 @@ func TestJoinHandler_Off(t *testing.T) {
 }
 
 func TestJoinHandlerWithAllowList_Off(t *testing.T) {
-	var name string
-	name = "TEST_NAME"
+	var name string = "TEST_NAME"
 	ctrl := gomock.NewController(t)
 
 	defer ctrl.Finish()
@@ -255,8 +254,7 @@ func TestPartHandler_Off(t *testing.T) {
 }
 
 func TestPartHandlerWithAllowList_Off(t *testing.T) {
-	var name string
-	name = "TEST_NAME"
+	var name string = "TEST_NAME"
 
 	ctrl := gomock.NewController(t)
 
@@ -406,8 +404,7 @@ func TestQuitHandler_Off(t *testing.T) {
 }
 
 func TestQuitHandlerWithAllowList_Off(t *testing.T) {
-	var name string
-	name = "TEST_NAME"
+	var name string = "TEST_NAME"
 
 	ctrl := gomock.NewController(t)
 


### PR DESCRIPTION
Fixes an issue caught by golangci-lint, and causes the CI pipeline to pass successfully again.

_Note_: Merging this and then rebasing PR #387 will cause all the failing tests to start passing. See the CircleCI failed job logs for more context on why this PR is proposed.