### PR TITLE
Fix nil pointer crash if telegram auth fails

### DIFF
--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -57,6 +57,12 @@ func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 		tg.logger.LogError(err)
 		errChan <- err
 	}
+
+	if tg.api == nil {
+		tg.logger.LogError("Failed to authorize to Telegram")
+		errChan <- err
+	}
+
 	tg.logger.LogInfo("Authorized on account", tg.api.Self.UserName)
 	tg.sendToIrc = sendMessage
 

--- a/internal/handlers/telegram/telegram.go
+++ b/internal/handlers/telegram/telegram.go
@@ -59,7 +59,7 @@ func (tg *Client) StartBot(errChan chan<- error, sendMessage func(string)) {
 	}
 
 	if tg.api == nil {
-		tg.logger.LogError("Failed to authorize to Telegram")
+		tg.logger.LogError("Failed to authenticate to Telegram")
 		errChan <- err
 	}
 


### PR DESCRIPTION
Random discovery of the evening :)
I'm not sure if there's a timing problem or if in some cases we don't get back an error. I can replicate this by deleting a character off the telegram key I'm using.

Alternatively there's something else entirely going on here and this just masks it.

Before:
```
$ ./teleirc
INFO: 2022/03/29 21:46:58 Current TeleIRC version: v2.2.0-9-g129dcac
INFO: 2022/03/29 21:46:58 Creating new Telegram bot client...
INFO: 2022/03/29 21:46:58 Creating new IRC bot client...
INFO: 2022/03/29 21:46:58 Starting up Telegram bot...
INFO: 2022/03/29 21:46:58 Starting up IRC bot...
ERROR: 2022/03/29 21:47:03 Unauthorized
ERROR: 2022/03/29 21:47:03 Unauthorized
INFO: 2022/03/29 21:47:03 Shutting Down...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x69d3c9]

goroutine 9 [running]:
github.com/ritlug/teleirc/internal/handlers/telegram.(*Client).StartBot(0xc0002c1640, 0x0?, 0xc0002c1680)
        /home/nate/projects/teleirc/internal/handlers/telegram/telegram.go:60 +0x1a9
created by main.main
        /home/nate/projects/teleirc/cmd/teleirc.go:53 +0x5f8
```

After:
```
$ ./teleirc
INFO: 2022/03/29 22:06:29 Current TeleIRC version: v2.2.0-11-g5a08266
INFO: 2022/03/29 22:06:29 Creating new Telegram bot client...
INFO: 2022/03/29 22:06:29 Creating new IRC bot client...
INFO: 2022/03/29 22:06:29 Starting up Telegram bot...
INFO: 2022/03/29 22:06:29 Starting up IRC bot...
ERROR: 2022/03/29 22:06:30 Unauthorized
ERROR: 2022/03/29 22:06:30 Failed to authenticate to Telegram
ERROR: 2022/03/29 22:06:30 Unauthorized
INFO: 2022/03/29 22:06:30 Shutting Down...
INFO: 2022/03/29 22:06:30 Exiting
```