### PR TITLE
Fix inverted debug flag help message

### DIFF
--- a/cmd/teleirc.go
+++ b/cmd/teleirc.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	flagPath    = flag.String("conf", ".env", "config file")
-	flagDebug   = flag.Bool("debug", false, "disable debugging")
+	flagDebug   = flag.Bool("debug", false, "enable debugging output")
 	flagVersion = flag.Bool("version", false, "displays current version of TeleIRC")
 	version     string
 )


### PR DESCRIPTION
The current `-help` message says that the `-debug` flag will "disable debugging", when it actually enables debugging.
Trivial change, so not tested