### PR TITLE
Update systemd deployment resources

### DIFF
--- a/deployments/systemd/teleirc.sysusers
+++ b/deployments/systemd/teleirc.sysusers
@@ -1,0 +1,1 @@
+u teleirc - "TeleIRC Service"

--- a/deployments/systemd/teleirc.tmpfiles
+++ b/deployments/systemd/teleirc.tmpfiles
@@ -1,0 +1,1 @@
+d /etc/teleirc 550 teleirc teleirc - -

--- a/deployments/systemd/teleirc@.service
+++ b/deployments/systemd/teleirc@.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=TeleIRC: Telegram + IRC bridge bot
+Description=TeleIRC: Telegram + IRC bridge bot for %I
 Requires=network.target
 After=multi-user.target
 
 [Service]
 Type=simple
 User=teleirc
-ExecStart=/usr/local/bin/teleirc -conf /etc/teleirc/env
+ExecStart=/usr/local/bin/teleirc -conf /etc/teleirc/%i
 Restart=always
 RestartSec=60
 

--- a/docs/user/quick-start.md
+++ b/docs/user/quick-start.md
@@ -182,36 +182,39 @@ Upstream offers a [systemd unit file][15] to automate TeleIRC on a Linux system 
 This example uses the upstream systemd unit file to automatically run TeleIRC on a Linux system.
 
 This example was tested on a CentOS 8 system and is easily adaptable for other `*NIX` distributions.
-It uses `v2.0.0` as a default:
+It uses `v2.2.1` as a default:
 
 ```sh
-# Change ~/teleirc and ~/teleirc-env with equivalents on your system.
-
 # Download TeleIRC deployment assets from GitHub.
-$ curl --location --output ~/teleirc https://github.com/RITlug/teleirc/releases/download/v2.0.0/teleirc-2.0.0-linux-64bit
-$ curl --location --output ~/teleirc-env https://raw.githubusercontent.com/RITlug/teleirc/v2.0.0/env.example
-$ curl --location --output ~/teleirc.service https://raw.githubusercontent.com/RITlug/teleirc/v2.0.0/deployments/systemd/teleirc.service
+$ curl --location --output ~/teleirc https://github.com/RITlug/teleirc/releases/download/v2.2.1/teleirc-2.2.1-linux-x86_64
+$ curl --location --output ~/teleirc.sysusers https://raw.githubusercontent.com/RITlug/teleirc/v2.2.1/deployments/systemd/teleirc.sysusers
+$ curl --location --output ~/teleirc.tmpfiles https://raw.githubusercontent.com/RITlug/teleirc/v2.2.1/deployments/systemd/teleirc.tmpfiles
+$ curl --location --output ~/teleirc@.service https://raw.githubusercontent.com/RITlug/teleirc/v2.2.1/deployments/systemd/teleirc@.service
+$ curl --location --output ~/teleirc.env https://raw.githubusercontent.com/RITlug/teleirc/v2.2.1/env.example
 
-# Harden/fix file permissions.
-$ chmod 755 ~/teleirc
-$ chmod 600 ~/teleirc-env
-$ chmod 644 ~/teleirc.service
-
-# Install TeleIRC locally on system.
-$ sudo chown root:root ~/teleirc*
-$ mkdir -p /etc/teleirc/
-$ sudo mv ~/teleirc /usr/local/bin/teleirc
-$ sudo mv ~/teleirc-env /etc/teleirc/env
-$ sudo mv ~/teleirc.service /usr/lib/systemd/system/multi-user.target.wants/teleirc.service
+# Install TeleIRC files and user
+$ sudo install -Dm755 -o root -g root ~/teleirc /usr/local/bin/teleirc
+$ sudo install -Dm644 -o root -g root ~/teleirc.sysusers /etc/sysusers.d/teleirc.conf
+$ sudo install -Dm644 -o root -g root ~/teleirc.tmpfiles /etc/tmpfiles.d/teleirc.conf
+$ sudo install -Dm644 -o root -g root ~/teleirc@.service /etc/systemd/system/teleirc@.service
+$ sudo systemd-sysusers /etc/sysusers.d/teleirc.conf
+$ sudo systemd-tmpfiles --create /etc/tmpfiles.d/teleirc.conf
+$ sudo install -Dm644 -o root -g root ~/teleirc.env /etc/teleirc/example
+$ rm ~/teleirc ~/teleirc.sysusers ~/teleirc.tmpfiles ~/teleirc@.service ~/teleirc.env
 
 # Systems with SELinux ONLY.
 $ sudo chcon --type bin_t --user system_u /usr/local/bin/teleirc
-$ sudo chcon --type etc_t --user system_u /etc/teleirc/env
-$ sudo chcon --type systemd_unit_file_t --user system_u /usr/lib/systemd/system/multi-user.target.wants/teleirc.service
+$ sudo chcon --type etc_t --user system_u -R /etc/teleirc/
+$ sudo chcon --type etc_t --user system_u /etc/sysusers.d/teleirc.conf
+$ sudo chcon --type etc_t --user system_u /etc/tmpfiles.d/teleirc.conf
+$ sudo chcon --type systemd_unit_file_t --user system_u /etc/systemd/system/teleirc@.service
 
 # Start and enable TeleIRC.
-$ sudo systemctl enable --now teleirc.service
+$ sudo systemctl enable --now teleirc@example.service
 ```
+
+To run multiple instances, create other files in /etc/teleirc/ and enable the
+service named teleirc@FILENAME.service.
 
 
 ## Run container
@@ -245,6 +248,6 @@ Needs better documentation by someone with experience running and using the cont
 [12]: https://github.com/RITlug/teleirc/issues/new/choose
 [13]: https://raw.githubusercontent.com/RITlug/teleirc/master/deployments/container/Dockerfile
 [14]: https://github.com/RITlug/teleirc/releases
-[15]: https://github.com/RITlug/teleirc/blob/master/deployments/systemd/teleirc.service
+[15]: https://github.com/RITlug/teleirc/blob/master/deployments/systemd/teleirc@.service
 [16]: https://systemd.io/
 [17]: https://github.com/jwflory/ansible-role-teleirc


### PR DESCRIPTION
- Use systemd-tmpfiles and systemd-sysusers
- Use service template for ease of running multiple instances
- Simplify installation commands (`chown`/`chmod` -> `install`)

Based on my [changes](https://github.com/half-duplex/aur-teleirc/commit/92fa701fd53b5df03148bdc8e69ff84c7aa0e1a6) to the [AUR package](https://aur.archlinux.org/packages/teleirc) for teleirc.

I wrote the download links for 2.2.1, if the release ends up being 2.3.0 or something those should be updated.