### PR TITLE
Imgur: Log deletion links

### DIFF
--- a/internal/handlers/telegram/imgur.go
+++ b/internal/handlers/telegram/imgur.go
@@ -79,5 +79,10 @@ func getImgurLink(tg *Client, tgLink string) string {
 		tg.logger.LogError("Could not retrieve imgur json data:", err)
 	}
 
+	if resp.Data.Deletehash != "" {
+		deleteLink := "https://imgur.com/delete/" + resp.Data.Deletehash
+		tg.logger.LogInfo("Deletion link for", resp.Data.Link, "is", deleteLink)
+	}
+
 	return resp.Data.Link
 }


### PR DESCRIPTION
The Imgur upload process currently discards the deletion links. Since images are uploaded anonymously, deletion links are the only practical way to remove them. This PR logs them as INFO.

I don't really speak golang, not sure if `!= ""` is the right conditional for `omitempty`