### PR TITLE
Strip mIRC formatting 

### DIFF
--- a/internal/handlers/irc/handlers.go
+++ b/internal/handlers/irc/handlers.go
@@ -3,6 +3,7 @@ package irc
 import (
 	"fmt"
 	"strings"
+	"regexp"
 
 	"github.com/lrstanley/girc"
 )
@@ -111,6 +112,8 @@ messageHandler handles the PRIVMSG IRC event, which entails both private
 and channel messages. However, it only cares about channel messages
 */
 func messageHandler(c ClientInterface) func(*girc.Client, girc.Event) {
+	var colorStripper = regexp.MustCompile(`[\x02\x1F\x0F\x16]|\x03(\d\d?(,\d\d?)?)?`);
+	
 	return func(gc *girc.Client, e girc.Event) {
 		c.Logger().LogDebug("messageHandler triggered")
 		// Only send if user is not in blacklist
@@ -129,7 +132,10 @@ func messageHandler(c ClientInterface) func(*girc.Client, girc.Event) {
 				if hasNoForwardPrefix(c, e.Params[1]) {
 					return // sender didn't want this forwarded
 				}
-
+				
+				// Strip of mIRC formatting
+				formatted = colorStripper.ReplaceAllString(formatted, "");
+				
 				c.SendToTg(formatted)
 			}
 		}

--- a/internal/handlers/irc/handlers.go
+++ b/internal/handlers/irc/handlers.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"regexp"
 
 	"github.com/lrstanley/girc"
 )


### PR DESCRIPTION
Added stripping of mIRC colors and other formatting.

This removes mIRC formatting such as \x0304,12 for colors from messages being sent to telegram from IRC 