### PR TITLE
Build static binary

### DIFF
--- a/build_binary.sh
+++ b/build_binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURRENT_VERSION=`git describe`
 go build -ldflags "-X main.version=$CURRENT_VERSION" cmd/teleirc.go

--- a/build_binary.sh
+++ b/build_binary.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
 CURRENT_VERSION=`git describe`
-go build -ldflags "-X main.version=$CURRENT_VERSION" cmd/teleirc.go
+CGO_ENABLED=0 go build -asmflags -trimpath \
+	-ldflags "-s -w -X main.version=$CURRENT_VERSION" cmd/teleirc.go
+

--- a/docs/user/quick-start.md
+++ b/docs/user/quick-start.md
@@ -148,7 +148,7 @@ This section is only required if you are building a binary from source:
 
 1. Clone repository (`git clone https://github.com/RITlug/teleirc.git`)
 1. Enter repository (`cd teleirc/`)
-1. Build binary (`go build cmd/teleirc.go`)
+1. Build binary (`./build_binary.sh`)
 
 #### Configuration
 


### PR DESCRIPTION
This pull request compiles binary to static so it's easier to move binary around different machines having the same architecture. Also, removed debug symbols and build related paths from the binary that reduced the size from ~8MB down to 5MB.