### PR TITLE
Fix encoding when splitting string

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -97,8 +97,8 @@ func replyHandler(tg *Client, u tgbotapi.Update) {
 	replyUser := GetUsername(tg.IRCSettings.ShowZWSP, u.Message.ReplyToMessage.From)
 
 	// Only show a portion of the reply text
-	if len(replyText) > tg.Settings.ReplyLength {
-		replyText = replyText[0:tg.Settings.ReplyLength] + "…"
+	if replyTextAsRunes := []rune(replyText); len(replyTextAsRunes) > tg.Settings.ReplyLength {
+		replyText = string(replyTextAsRunes[:tg.Settings.ReplyLength]) + "…"
 	}
 
 	formatted := fmt.Sprintf("%s%s%s %sRe %s: %s%s %s",

--- a/internal/handlers/telegram/helpers.go
+++ b/internal/handlers/telegram/helpers.go
@@ -37,7 +37,8 @@ Adds ZWSP to username to prevent username pinging across platform.
 func GetFullUserZwsp(u *tgbotapi.User) string {
 	// Add ZWSP to prevent pinging across platforms
 	// See https://github.com/42wim/matterbridge/issues/175
-	return u.FirstName + " (@" + u.UserName[:1] + "\u200b" + u.UserName[1:] + ")"
+	userNameAsRunes := []rune(u.UserName)
+	return u.FirstName + " (@" + string(userNameAsRunes[:1]) + "\u200b" + string(userNameAsRunes[1:]) + ")"
 }
 
 /*
@@ -47,7 +48,8 @@ username.
 func ZwspUsername(u *tgbotapi.User) string {
 	// Add ZWSP to prevent pinging across platforms
 	// See https://github.com/42wim/matterbridge/issues/175
-	return u.UserName[:1] + "\u200b" + u.UserName[1:]
+	userNameAsRunes := []rune(u.UserName)
+	return string(userNameAsRunes[:1]) + "\u200b" + string(userNameAsRunes[1:])
 }
 
 /*

--- a/internal/handlers/telegram/helpers_test.go
+++ b/internal/handlers/telegram/helpers_test.go
@@ -16,12 +16,34 @@ func TestGetFullUsername(t *testing.T) {
 }
 
 func TestGetFullUserZwsp(t *testing.T) {
-	user := &tgbotapi.User{ID: 1, FirstName: "John", UserName: "jsmith"}
-	correct := user.FirstName + " (@" + user.UserName[:1] +
-		"\u200b" + user.UserName[1:] + ")"
-	name := GetFullUsername(true, user)
+	tests := []struct {
+		name     string
+		user     *tgbotapi.User
+		expected string
+	}{
+		{
+			name:     "ascii",
+			user:     &tgbotapi.User{ID: 1, FirstName: "John", UserName: "jsmith"},
+			expected: "John (@j\u200bsmith)",
+		},
+		{
+			name:     "cyrillic",
+			user:     &tgbotapi.User{ID: 1, FirstName: "Иван", UserName: "иван"},
+			expected: "Иван (@и\u200bван)",
+		},
+		{
+			name:     "japanese",
+			user:     &tgbotapi.User{ID: 1, FirstName: "まこと", UserName: "まこと"},
+			expected: "まこと (@ま\u200bこと)",
+		},
+	}
 
-	assert.Equal(t, correct, name)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetFullUsername(true, test.user)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
 }
 
 func TestGetFullNoUsername(t *testing.T) {
@@ -49,9 +71,32 @@ func TestGetUsername(t *testing.T) {
 }
 
 func TestZwspUsername(t *testing.T) {
-	user := &tgbotapi.User{ID: 1, FirstName: "John", UserName: "jsmith"}
-	correct := "j" + "\u200b" + "smith"
-	name := GetUsername(true, user)
+	tests := []struct {
+		name     string
+		user     *tgbotapi.User
+		expected string
+	}{
+		{
+			name:     "ascii",
+			user:     &tgbotapi.User{ID: 1, FirstName: "John", UserName: "jsmith"},
+			expected: "j\u200bsmith",
+		},
+		{
+			name:     "cyrillic",
+			user:     &tgbotapi.User{ID: 1, FirstName: "Иван", UserName: "иван"},
+			expected: "и\u200bван",
+		},
+		{
+			name:     "japanese",
+			user:     &tgbotapi.User{ID: 1, FirstName: "まこと", UserName: "まこと"},
+			expected: "ま\u200bこと",
+		},
+	}
 
-	assert.Equal(t, correct, name)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetUsername(true, test.user)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
When using a byte substring operation on a multibyte string, it is possible to split a multibyte character in half, which produces broken UTF-8 output.

This commit fixes all occurences of the problem:
- when dealing with usernames
- when replying to Telegram messages.

Also, tests with multibyte character sets (Cyrillic, Japanese) are added.