### PR TITLE
Check if IRC messages come from the expected channel

### DIFF
--- a/internal/handlers/irc/handlers.go
+++ b/internal/handlers/irc/handlers.go
@@ -113,13 +113,16 @@ and channel messages. However, it only cares about channel messages
 */
 func messageHandler(c ClientInterface) func(*girc.Client, girc.Event) {
 	var colorStripper = regexp.MustCompile(`[\x02\x1F\x0F\x16]|\x03(\d\d?(,\d\d?)?)?`)
+	var ircChannel = c.IRCSettings().Channel
 
 	return func(gc *girc.Client, e girc.Event) {
 		c.Logger().LogDebug("messageHandler triggered")
-		// Only send if user is not in blacklist
-		if !(checkBlacklist(c, e.Source.Name)) {
 
-			if e.IsFromChannel() {
+		// Only send if user is not in blacklist ...
+		if !(checkBlacklist(c, e.Source.Name)) {
+			// ... and if the channel matches. Array index is safe because IsFromChannel
+			// itself does it this way.
+			if e.IsFromChannel() && e.Params[0] == ircChannel {
 				formatted := ""
 				if e.IsAction() {
 					msg := e.Last()


### PR DESCRIPTION
In some setups, teleirc might be running behind an IRC bouncer managing a bot account that is a member of multiple channels. In these cases teleirc will receive messages for channels that are not bridged to Telegram.

To avoid accidentally forwarding these messages to Telegram, this commit explicitly checks that the channel from which a message is received matches the channel that is configured in teleirc.

Note that girc code itself fetches the channel name using this array index in `IsFromChannel`.

---------

For context: At [TVL](http://tvl.fyi/) we run a variety of IRC bots that do useful things in our channels, but most of them run through the same IRC user (called `tvlbot`). This is done by running a ZNC bouncer on a machine that is connected to IRC, and having the various bots connected to this ZNC. For our users this looks as if `tvlbot` was one big magic bot that does everything, and also avoids having to name and individually maintain bots, plus gives us automatic handling of backlog etc. when individual bots are restarted.

We tried running `teleirc` for the [Volga Sprint](https://volgasprint.org/) channel, which is an event where, slightly exaggerated, half the people only have IRC and the other half only have Telegram. We set it up through our normal ZNC setup and found that it forwards messages from *all* channels that tvlbot is in to the Telegram group.

We have [deployed this change](https://cl.tvl.fyi/c/depot/+/11731) and verified that it fixes the issue.
