### PR TITLE
Add error handling for empty imgur link

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -165,9 +165,14 @@ func photoHandler(tg *Client, u tgbotapi.Update) {
 	if caption == "" {
 		caption = "No caption provided."
 	}
-	formatted := "'" + caption + "' uploaded by " + username + ": " + link
 
-	tg.sendToIrc(formatted)
+	// TeleIRC can fail to upload to Imgur
+	if link == "" {
+		tg.logger.LogError("Failed imgur photo upload for", username)
+	} else {
+		formatted := "'" + caption + "' uploaded by " + username + ": " + link
+		tg.sendToIrc(formatted)
+	}
 }
 
 /*

--- a/internal/handlers/telegram/imgur.go
+++ b/internal/handlers/telegram/imgur.go
@@ -98,6 +98,11 @@ func getImgurLink(tg *Client, tgLink string) string {
 		tg.logger.LogError("Could not retrieve imgur json data:", err)
 	}
 
+    if resp.Data == nil {
+        tg.logger.LogError("Imgur response data was null. Possible API rate limiting.")
+        return ""
+    }
+
 	if resp.Data.Deletehash != "" {
 		deleteLink := "https://imgur.com/delete/" + resp.Data.Deletehash
 		tg.logger.LogInfo("Deletion link for", resp.Data.Link, "is", deleteLink)

--- a/internal/handlers/telegram/imgur.go
+++ b/internal/handlers/telegram/imgur.go
@@ -98,10 +98,10 @@ func getImgurLink(tg *Client, tgLink string) string {
 		tg.logger.LogError("Could not retrieve imgur json data:", err)
 	}
 
-    if resp.Data == nil {
-        tg.logger.LogError("Imgur response data was null. Possible API rate limiting.")
-        return ""
-    }
+	if resp.Data == nil {
+		tg.logger.LogError("Imgur response data was null. Possible API rate limiting.")
+		return ""
+	}
 
 	if resp.Data.Deletehash != "" {
 		deleteLink := "https://imgur.com/delete/" + resp.Data.Deletehash


### PR DESCRIPTION
# Summary
Based off issue https://github.com/RITlug/teleirc/issues/434, TeleIRC can fatally crash if the Imgur link is missing. The most common reason for this is due to Imgur rate limiting. 

closes #434 