### PR TITLE
Do not process ANY messages from other Telegram Chats ≠ the bridged Chat ID

### DIFF
--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -21,6 +21,13 @@ which handler to fire off
 */
 func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 	for u := range updates {
+		// Don't process any messages that didn't come from the
+		// chat we're bridging
+		if u.Message.Chat.ID != tg.Settings.ChatID {
+			tg.logger.LogDebug("Ignored message from a telegram chat we're not bridging:", tg.Settings.ChatID)
+			continue
+		}
+
 		switch {
 		case u.Message == nil:
 			tg.logger.LogError("Missing message data")
@@ -63,12 +70,6 @@ func messageHandler(tg *Client, u tgbotapi.Update) {
 	formatted := ""
 
 	if tg.IRCSettings.NoForwardPrefix != "" && strings.HasPrefix(u.Message.Text, tg.IRCSettings.NoForwardPrefix) {
-		return
-	}
-
-	// Don't forward messages to IRC that didn't come from the
-	// chat we're bridging
-	if u.Message.Chat.ID != tg.Settings.ChatID {
 		return
 	}
 

--- a/internal/handlers/telegram/handler.go
+++ b/internal/handlers/telegram/handler.go
@@ -21,16 +21,16 @@ which handler to fire off
 */
 func updateHandler(tg *Client, updates tgbotapi.UpdatesChannel) {
 	for u := range updates {
-		// Don't process any messages that didn't come from the
-		// chat we're bridging
-		if u.Message.Chat.ID != tg.Settings.ChatID {
-			tg.logger.LogDebug("Ignored message from a telegram chat we're not bridging:", tg.Settings.ChatID)
-			continue
-		}
-
 		switch {
 		case u.Message == nil:
-			tg.logger.LogError("Missing message data")
+			// Non-message updates (edited messages, reactions, polls, inline
+			// queries, channel posts, etc.) are normal; skip silently.
+			tg.logger.LogDebug("Skipping non-message Telegram update")
+			continue
+		case u.Message.Chat.ID != tg.Settings.ChatID:
+			// Don't process any messages that didn't come from the
+			// chat we're bridging
+			tg.logger.LogDebug("Ignored message from a telegram chat we're not bridging:", u.Message.Chat.ID)
 			continue
 		case u.Message.NewChatMembers != nil:
 			tg.logger.LogDebug("joinHandler triggered")


### PR DESCRIPTION
Discards any Messages form non-bridged Telegram Chat IDs the Bot «can read», but are not in scope. Better early prevention to process any arbitrary messages or objects.

Why?
Allows reusing an existing Telegram Bot, which is connected to multiple Chats.

Could also make the last step of the Quick Start Guide «[Create bot with BotFather](https://docs.teleirc.com/en/latest/user/quick-start/#create-bot-with-botfather)» obsolete / less critical:
- ~Send /setjoingroups to `@BotFather`, change to Disable~
